### PR TITLE
ref(v7): Update mechanism signal to latest spec

### DIFF
--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -305,7 +305,7 @@ impl<T> From<*mut T> for Addr {
 }
 
 impl Into<u64> for Addr {
-    fn into(self: Addr) -> u64 {
+    fn into(self) -> u64 {
         self.0
     }
 }
@@ -357,7 +357,7 @@ impl<T> From<*mut T> for RegVal {
 }
 
 impl Into<u64> for RegVal {
-    fn into(self: RegVal) -> u64 {
+    fn into(self) -> u64 {
         self.0
     }
 }
@@ -401,7 +401,7 @@ impl From<u32> for HResult {
 }
 
 impl Into<u32> for HResult {
-    fn into(self: HResult) -> u32 {
+    fn into(self) -> u32 {
         self.0
     }
 }
@@ -419,13 +419,13 @@ impl From<u32> for Win32ErrorCode {
 }
 
 impl Into<u32> for Win32ErrorCode {
-    fn into(self: Win32ErrorCode) -> u32 {
+    fn into(self) -> u32 {
         self.0
     }
 }
 
 /// Mach exception information.
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct MachException {
     /// The mach exception type.
     #[serde(rename = "exception")]
@@ -436,6 +436,35 @@ pub struct MachException {
     pub subcode: u64,
 }
 
+/// POSIX signal with optional extended data.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct PosixSignal {
+    /// The POSIX signal number.
+    pub number: i32,
+    /// An optional signal code present on Apple systems.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<i32>,
+}
+
+impl From<i32> for PosixSignal {
+    fn from(number: i32) -> PosixSignal {
+        PosixSignal { number, code: None }
+    }
+}
+
+impl From<(i32, i32)> for PosixSignal {
+    fn from(tuple: (i32, i32)) -> PosixSignal {
+        let (number, code) = tuple;
+        PosixSignal { number, code: Some(code) }
+    }
+}
+
+impl Into<i32> for PosixSignal {
+    fn into(self) -> i32 {
+        self.number
+    }
+}
+
 /// Operating system or runtime meta information to an exception mechanism.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct MechanismMeta {
@@ -444,7 +473,7 @@ pub struct MechanismMeta {
     pub errno: Option<i32>,
     /// Optional POSIX signal number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub signal: Option<i32>,
+    pub signal: Option<PosixSignal>,
     /// Optional mach exception information.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mach_exception: Option<MachException>,

--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -455,7 +455,10 @@ impl From<i32> for PosixSignal {
 impl From<(i32, i32)> for PosixSignal {
     fn from(tuple: (i32, i32)) -> PosixSignal {
         let (number, code) = tuple;
-        PosixSignal { number, code: Some(code) }
+        PosixSignal {
+            number,
+            code: Some(code),
+        }
     }
 }
 

--- a/tests/test_protocol_v7.rs
+++ b/tests/test_protocol_v7.rs
@@ -1000,8 +1000,8 @@ fn test_exception_mechanism() {
         "{\"exception\":{\"values\":[{\"type\":\"EXC_BAD_ACCESS\",\"value\":\"Attempted to \
          dereference garbage pointer 0x1\",\"mechanism\":{\"type\":\"mach\",\"help_link\":\"\
          https://developer.apple.com/library/content/qa/qa1367/_index.html\",\"handled\":false,\"\
-         data\":{\"relevant_address\":\"0x1\"},\"meta\":{\"signal\":11,\"mach_exception\":{\"\
-         exception\":1,\"code\":1,\"subcode\":8}}}}]}}"
+         data\":{\"relevant_address\":\"0x1\"},\"meta\":{\"signal\":{\"number\":11},\"mach_exception\
+         \":{\"exception\":1,\"code\":1,\"subcode\":8}}}}]}}"
     );
 }
 

--- a/tests/test_protocol_v7.rs
+++ b/tests/test_protocol_v7.rs
@@ -979,7 +979,10 @@ fn test_exception_mechanism() {
                         map
                     },
                     meta: v7::MechanismMeta {
-                        signal: Some(11.into()),
+                        signal: Some(v7::PosixSignal {
+                            number: 11,
+                            code: None,
+                        }),
                         mach_exception: Some(v7::MachException {
                             ty: 1,
                             code: 1,


### PR DESCRIPTION
Changes `mechanism.meta.signal` to

```rust
pub struct PosixSignal {
    pub number: i32,
    pub code: Option<i32>,
}
```