### PR TITLE
fix(dsn): Support owned deserialization for DSNs

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -21,7 +21,7 @@ macro_rules! impl_str_serialization {
             where
                 D: ::serde::de::Deserializer<'de>,
             {
-                <&str>::deserialize(deserializer)?
+                <::std::borrow::Cow<str>>::deserialize(deserializer)?
                     .parse()
                     .map_err(::serde::de::Error::custom)
             }
@@ -54,22 +54,23 @@ macro_rules! impl_serde_hex {
             {
                 #[derive(Deserialize)]
                 #[serde(untagged)]
-                enum Repr {
-                    Str(String),
+                enum Repr<'a> {
+                    #[serde(borrow)]
+                    Str(::std::borrow::Cow<'a, str>),
                     Uint($num),
                 }
 
                 Ok(match Repr::deserialize(deserializer)? {
-                    Repr::Str(s) => s.parse().map_err(D::Error::custom)?,
+                    Repr::Str(s) => s.parse().map_err(::serde::de::Error::custom)?,
                     Repr::Uint(val) => $type(val),
                 })
             }
         }
 
-        impl str::FromStr for $type {
-            type Err = ParseIntError;
+        impl ::std::str::FromStr for $type {
+            type Err = ::std::num::ParseIntError;
 
-            fn from_str(s: &str) -> Result<$type, ParseIntError> {
+            fn from_str(s: &str) -> Result<$type, ::std::num::ParseIntError> {
                 if s.starts_with("0x") || s.starts_with("0X") {
                     $num::from_str_radix(&s[2..], 16).map($type)
                 } else {
@@ -78,10 +79,96 @@ macro_rules! impl_serde_hex {
             }
         }
 
-        impl fmt::Display for $type {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        impl ::std::fmt::Display for $type {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 write!(f, "{:#x}", self.0)
             }
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt;
+    use std::io::Cursor;
+    use std::str::FromStr;
+
+    use serde_json;
+
+    struct Test;
+
+    impl FromStr for Test {
+        type Err = &'static str;
+
+        fn from_str(string: &str) -> Result<Self, Self::Err> {
+            match string {
+                "test" => Ok(Test),
+                _ => Err("failed"),
+            }
+        }
+    }
+
+    impl fmt::Display for Test {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "test")
+        }
+    }
+
+    impl_str_serialization!(Test);
+
+    #[test]
+    fn test_serialize_string() {
+        assert_eq!("\"test\"", serde_json::to_string(&Test).unwrap());
+    }
+
+    #[test]
+    fn test_deserialize() {
+        assert!(serde_json::from_str::<Test>("\"test\"").is_ok());
+    }
+
+    #[test]
+    fn test_deserialize_owned() {
+        assert!(serde_json::from_reader::<_, Test>(Cursor::new("\"test\"")).is_ok());
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct Hex(u32);
+
+    impl_serde_hex!(Hex, u32);
+
+    #[test]
+    fn test_hex_to_string() {
+        assert_eq!("0x0", &Hex(0).to_string());
+        assert_eq!("0x2a", &Hex(42).to_string());
+    }
+
+    #[test]
+    fn test_hex_serialize() {
+        assert_eq!("\"0x0\"", serde_json::to_string(&Hex(0)).unwrap());
+        assert_eq!("\"0x2a\"", serde_json::to_string(&Hex(42)).unwrap());
+    }
+
+    #[test]
+    fn test_hex_from_string() {
+        assert_eq!(Hex(0), "0".parse().unwrap());
+        assert_eq!(Hex(42), "42".parse().unwrap());
+        assert_eq!(Hex(42), "0x2a".parse().unwrap());
+        assert_eq!(Hex(42), "0X2A".parse().unwrap());
+    }
+
+    #[test]
+    fn test_hex_deserialize() {
+        assert_eq!(Hex(0), serde_json::from_str("\"0\"").unwrap());
+        assert_eq!(Hex(42), serde_json::from_str("\"42\"").unwrap());
+        assert_eq!(Hex(42), serde_json::from_str("\"0x2a\"").unwrap());
+        assert_eq!(Hex(42), serde_json::from_str("\"0X2A\"").unwrap());
+    }
+
+    #[test]
+    fn test_hex_deserialize_owned() {
+        assert_eq!(Hex(0), serde_json::from_reader(Cursor::new("\"0\"")).unwrap());
+        assert_eq!(Hex(42), serde_json::from_reader(Cursor::new("\"42\"")).unwrap());
+        assert_eq!(Hex(42), serde_json::from_reader(Cursor::new("\"0x2a\"")).unwrap());
+        assert_eq!(Hex(42), serde_json::from_reader(Cursor::new("\"0X2A\"")).unwrap());
+    }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -166,9 +166,21 @@ mod tests {
 
     #[test]
     fn test_hex_deserialize_owned() {
-        assert_eq!(Hex(0), serde_json::from_reader(Cursor::new("\"0\"")).unwrap());
-        assert_eq!(Hex(42), serde_json::from_reader(Cursor::new("\"42\"")).unwrap());
-        assert_eq!(Hex(42), serde_json::from_reader(Cursor::new("\"0x2a\"")).unwrap());
-        assert_eq!(Hex(42), serde_json::from_reader(Cursor::new("\"0X2A\"")).unwrap());
+        assert_eq!(
+            Hex(0),
+            serde_json::from_reader(Cursor::new("\"0\"")).unwrap()
+        );
+        assert_eq!(
+            Hex(42),
+            serde_json::from_reader(Cursor::new("\"42\"")).unwrap()
+        );
+        assert_eq!(
+            Hex(42),
+            serde_json::from_reader(Cursor::new("\"0x2a\"")).unwrap()
+        );
+        assert_eq!(
+            Hex(42),
+            serde_json::from_reader(Cursor::new("\"0X2A\"")).unwrap()
+        );
     }
 }

--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -9,7 +9,6 @@ use std::cmp;
 use std::fmt;
 use std::iter::FromIterator;
 use std::net::{AddrParseError, IpAddr};
-use std::num::ParseIntError;
 use std::ops;
 use std::str;
 


### PR DESCRIPTION
This will allow to use serde's `::from_reader` methods, as they require owned deserialization. Also, the hex serialization now uses `Cow<str>` which should make it slightly faster for borrowed deserialization.

This fixes a bug that prevented semaphore from parsing it's Sentry SDK configuration:

```
error: could not parse yaml config file
  caused by: sentry.dsn: invalid type: string "...", expected a borrowed string
```