### PR TITLE
fix(v7): Use fingerprint behavior of sentry

### DIFF
--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -1380,51 +1380,51 @@ fn is_default_fingerprint<'a>(fp: &Cow<'a, [Cow<'a, str>]>) -> bool {
     fp.len() == 1 && ((&fp)[0] == "{{ default }}" || (&fp)[0] == "{{default}}")
 }
 
-/// Recursively collects values into a fingerprint list.
-///
-/// - Booleans, strings and integers are directly converted to string
-/// - Floating point numbers are truncated and then converted to string
-/// - Arrays are transformed recursively with the above rules and appended to the list
-/// - Objects and null values are ignored at all levels
-fn collect_fingerprint<'a>(fingerprint: &mut Vec<Cow<'a, str>>, value: Value) {
-    match value {
-        Value::Null => (),
-        Value::Object(_) => (),
-        Value::Bool(b) => fingerprint.push(b.to_string().into()),
-        Value::String(s) => fingerprint.push(s.into()),
-        Value::Number(n) => {
-            if let Some(u) = n.as_u64() {
-                fingerprint.push(u.to_string().into());
-            } else if let Some(i) = n.as_i64() {
-                fingerprint.push(i.to_string().into());
-            } else if let Some(f) = n.as_f64() {
-                if f.trunc() as i64 as f64 == f {
-                    fingerprint.push(f.trunc().to_string().into());
-                }
-            }
-        }
-        Value::Array(values) => {
-            for v in values {
-                collect_fingerprint(fingerprint, v);
-            }
-        }
-    }
-}
-
-/// Deserializes fingerprints into a flat list of strings.
+/// Deserializes fingerprints into a list of strings.
 fn deserialize_fingerprint<'a, 'de, D>(deserializer: D) -> Result<Cow<'a, [Cow<'a, str>]>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let value = Value::deserialize(deserializer)?;
-    let mut fingerprint = Vec::new();
-    collect_fingerprint(&mut fingerprint, value);
+    #[derive(Debug, Deserialize)]
+    #[serde(untagged)]
+    enum Fingerprint {
+        Bool(bool),
+        Number(value::Number),
+        String(String),
+    }
 
-    Ok(if fingerprint.is_empty() {
-        Cow::Borrowed(DEFAULT_FINGERPRINT)
-    } else {
-        Cow::Owned(fingerprint)
-    })
+    impl Into<Option<Cow<'static, str>>> for Fingerprint {
+        fn into(self) -> Option<Cow<'static, str>> {
+            match self {
+                Fingerprint::Bool(b) => Some(if b { "True" } else { "False" }.into()),
+                Fingerprint::Number(n) => {
+                    if let Some(u) = n.as_u64() {
+                        Some(u.to_string().into())
+                    } else if let Some(i) = n.as_i64() {
+                        Some(i.to_string().into())
+                    } else if let Some(f) = n.as_f64() {
+                        if f < (1i64 << 53) as f64 {
+                            Some(f.trunc().to_string().into())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                }
+                Fingerprint::String(s) => Some(s.into()),
+            }
+        }
+    }
+
+    let value = Value::deserialize(deserializer)?;
+    Ok(
+        if let Ok(fingerprint) = from_value::<Vec<Fingerprint>>(value) {
+            Cow::Owned(fingerprint.into_iter().filter_map(|f| f.into()).collect())
+        } else {
+            Cow::Borrowed(DEFAULT_FINGERPRINT)
+        },
+    )
 }
 
 impl<'a> Default for Event<'a> {

--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -1403,7 +1403,7 @@ where
                     } else if let Some(i) = n.as_i64() {
                         Some(i.to_string().into())
                     } else if let Some(f) = n.as_f64() {
-                        if f < (1i64 << 53) as f64 {
+                        if f.abs() < (1i64 << 53) as f64 {
                             Some(f.trunc().to_string().into())
                         } else {
                             None

--- a/tests/test_protocol_v7.rs
+++ b/tests/test_protocol_v7.rs
@@ -215,7 +215,7 @@ mod test_fingerprint {
                 fingerprint: Cow::Borrowed(&[]),
                 ..Default::default()
             },
-            serde_json::from_str("{\"fingerprint\":[1e100]}").unwrap()
+            serde_json::from_str("{\"fingerprint\":[-1e100]}").unwrap()
         )
     }
 

--- a/tests/test_protocol_v7.rs
+++ b/tests/test_protocol_v7.rs
@@ -165,6 +165,17 @@ mod test_fingerprint {
     }
 
     #[test]
+    fn test_fingerprint_bool() {
+        assert_eq!(
+            v7::Event {
+                fingerprint: Cow::Borrowed(&["True".into(), "False".into()]),
+                ..Default::default()
+            },
+            serde_json::from_str("{\"fingerprint\":[true, false]}").unwrap()
+        )
+    }
+
+    #[test]
     fn test_fingerprint_number() {
         assert_eq!(
             v7::Event {
@@ -187,57 +198,46 @@ mod test_fingerprint {
     }
 
     #[test]
-    fn test_fingerprint_array() {
+    fn test_fingerprint_float_trunc() {
         assert_eq!(
             v7::Event {
-                fingerprint: Cow::Borrowed(&["a".into(), "b".into(), "c".into(), "d".into()]),
+                fingerprint: Cow::Borrowed(&["3".into()]),
                 ..Default::default()
             },
-            serde_json::from_str("{\"fingerprint\":[\"a\",[\"b\",[\"c\"]],\"d\"]}").unwrap()
+            serde_json::from_str("{\"fingerprint\":[3.5]}").unwrap()
         )
     }
 
     #[test]
-    fn test_fingerprint_object() {
+    fn test_fingerprint_float_strip() {
         assert_eq!(
             v7::Event {
-                fingerprint: Cow::Borrowed(&["a".into(), "d".into()]),
+                fingerprint: Cow::Borrowed(&[]),
                 ..Default::default()
             },
-            serde_json::from_str("{\"fingerprint\":[\"a\",{\"b\":\"c\"},\"d\"]}").unwrap()
+            serde_json::from_str("{\"fingerprint\":[1e100]}").unwrap()
         )
     }
 
     #[test]
-    fn test_fingerprint_null() {
-        assert_eq!(
-            v7::Event {
-                fingerprint: Cow::Borrowed(&["a".into(), "b".into()]),
-                ..Default::default()
-            },
-            serde_json::from_str("{\"fingerprint\":[\"a\",null,\"b\"]}").unwrap()
-        )
-    }
-
-    #[test]
-    fn test_fingerprint_default() {
+    fn test_fingerprint_invalid_fallback() {
         assert_eq!(
             v7::Event {
                 fingerprint: Cow::Borrowed(&["{{ default }}".into()]),
                 ..Default::default()
             },
-            serde_json::from_str("{\"fingerprint\":[null, {}, [[]]]}").unwrap()
+            serde_json::from_str("{\"fingerprint\":[\"a\",null,\"d\"]}").unwrap()
         )
     }
 
     #[test]
-    fn test_fingerprint_toplevel() {
+    fn test_fingerprint_empty() {
         assert_eq!(
             v7::Event {
-                fingerprint: Cow::Borrowed(&["toplevel".into()]),
+                fingerprint: Cow::Borrowed(&[]),
                 ..Default::default()
             },
-            serde_json::from_str("{\"fingerprint\":\"toplevel\"}").unwrap()
+            serde_json::from_str("{\"fingerprint\":[]}").unwrap()
         )
     }
 
@@ -245,10 +245,10 @@ mod test_fingerprint {
     fn test_fingerprint_float_bounds() {
         assert_eq!(
             v7::Event {
-                fingerprint: Cow::Borrowed(&["a".into()]),
+                fingerprint: Cow::Borrowed(&[]),
                 ..Default::default()
             },
-            serde_json::from_str("{\"fingerprint\":[\"a\",1.7976931348623157e+308]}").unwrap()
+            serde_json::from_str("{\"fingerprint\":[1.7976931348623157e+308]}").unwrap()
         )
     }
 }


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/8726

Only difference to Sentry is that we do not reject `"fingerprint": null`, but Sentry will.