### PR TITLE
ref: Remove lenient deserialization logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
   include:
     - env: SUITE=test
     - env: SUITE=test
-      rust: "1.21.0"
+      rust: "1.28.0"
     - env: SUITE=format-check
       install: rustup component add rustfmt-preview
     - env: SUITE=lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,15 @@ exclude = [
 [features]
 default = ["with_protocol", "with_serde"]
 with_protocol = ["with_serde"]
-with_serde = ["serde", "serde_derive", "serde_json", "url_serde", "chrono/serde", "uuid/serde", "linked-hash-map/serde_impl", "debugid/with_serde"]
+with_serde = [
+    "serde",
+    "serde_derive",
+    "serde_json",
+    "url_serde",
+    "chrono/serde",
+    "uuid/serde",
+    "debugid/with_serde"
+]
 
 [badges]
 travis-ci = { repository = "getsentry/rust-sentry-types" }
@@ -28,9 +36,8 @@ failure_derive = "0.1.2"
 url = "1.7.1"
 serde = { version = "1.0.76", optional = true }
 serde_derive = { version = "1.0.76", optional = true }
-serde_json = { version = "1.0.26", features = ["preserve_order"], optional = true }
+serde_json = { version = "1.0.26", optional = true }
 url_serde = { version = "0.2.0", optional = true }
 chrono = "0.4.6"
 uuid = { version = "0.6.5", features = ["v4"] }
-linked-hash-map = "0.5.1"
 debugid = "0.2.0"

--- a/src/dsn.rs
+++ b/src/dsn.rs
@@ -188,7 +188,7 @@ impl FromStr for Dsn {
     }
 }
 
-impl_str_serialization!(Dsn);
+impl_str_serde!(Dsn);
 
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@ extern crate serde_derive;
 extern crate chrono;
 extern crate debugid;
 extern crate failure;
-extern crate linked_hash_map;
 #[cfg(feature = "with_serde")]
 extern crate serde;
 #[cfg(feature = "with_serde")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,9 +1,9 @@
 /// Helper macro to implement string based serialization.
 ///
-/// If a type implements `FromStr` and `Display` then this automatically
-/// implements a serializer/deserializer for that type that dispatches
+/// If a type implements `Display` then this automatically
+/// implements a serializer for that type that dispatches
 /// appropriately.
-macro_rules! impl_str_serialization {
+macro_rules! impl_str_ser {
     ($type:ty) => {
         #[cfg(feature = "with_serde")]
         impl ::serde::ser::Serialize for $type {
@@ -14,7 +14,17 @@ macro_rules! impl_str_serialization {
                 serializer.serialize_str(&self.to_string())
             }
         }
+    };
+}
 
+/// Helper macro to implement string based deserialization.
+///
+/// If a type implements `FromStr` then this automatically
+/// implements a deserializer for that type that dispatches
+/// appropriately.
+#[allow(unused_macros)]
+macro_rules! impl_str_de {
+    ($type:ty) => {
         #[cfg(feature = "with_serde")]
         impl<'de> ::serde::de::Deserialize<'de> for $type {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -29,66 +39,21 @@ macro_rules! impl_str_serialization {
     };
 }
 
-/// Helper macro to implement serialization from both numeric values or their
-/// hex representation as string.
+/// Helper macro to implement string based serialization and deserialization.
 ///
-/// This implements `Serialize`, `Deserialize`, `Display` and `FromStr`.
-/// Serialization will always use a `"0xbeef"` representation of the value.
-/// Deserialization supports raw numbers as well as string representations
-/// in hex and base10.
-macro_rules! impl_serde_hex {
-    ($type:ident, $num:ident) => {
-        impl ::serde::ser::Serialize for $type {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: ::serde::ser::Serializer,
-            {
-                serializer.serialize_str(&self.to_string())
-            }
-        }
-
-        impl<'de> ::serde::de::Deserialize<'de> for $type {
-            fn deserialize<D>(deserializer: D) -> Result<$type, D::Error>
-            where
-                D: ::serde::de::Deserializer<'de>,
-            {
-                #[derive(Deserialize)]
-                #[serde(untagged)]
-                enum Repr<'a> {
-                    #[serde(borrow)]
-                    Str(::std::borrow::Cow<'a, str>),
-                    Uint($num),
-                }
-
-                Ok(match Repr::deserialize(deserializer)? {
-                    Repr::Str(s) => s.parse().map_err(::serde::de::Error::custom)?,
-                    Repr::Uint(val) => $type(val),
-                })
-            }
-        }
-
-        impl ::std::str::FromStr for $type {
-            type Err = ::std::num::ParseIntError;
-
-            fn from_str(s: &str) -> Result<$type, ::std::num::ParseIntError> {
-                if s.starts_with("0x") || s.starts_with("0X") {
-                    $num::from_str_radix(&s[2..], 16).map($type)
-                } else {
-                    $num::from_str_radix(&s, 10).map($type)
-                }
-            }
-        }
-
-        impl ::std::fmt::Display for $type {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                write!(f, "{:#x}", self.0)
-            }
-        }
+/// If a type implements `FromStr` and `Display` then this automatically
+/// implements a serializer/deserializer for that type that dispatches
+/// appropriately.
+#[allow(unused_macros)]
+macro_rules! impl_str_serde {
+    ($type:ty) => {
+        impl_str_ser!($type);
+        impl_str_de!($type);
     };
 }
 
 #[cfg(test)]
-mod tests {
+mod str_tests {
     use std::fmt;
     use std::io::Cursor;
     use std::str::FromStr;
@@ -114,7 +79,7 @@ mod tests {
         }
     }
 
-    impl_str_serialization!(Test);
+    impl_str_serde!(Test);
 
     #[test]
     fn test_serialize_string() {
@@ -130,11 +95,104 @@ mod tests {
     fn test_deserialize_owned() {
         assert!(serde_json::from_reader::<_, Test>(Cursor::new("\"test\"")).is_ok());
     }
+}
+
+/// Helper macro to implement serialization into base 16 (hex) string
+/// representation. Implements `Display` and `Serialize`.
+macro_rules! impl_hex_ser {
+    ($type:ident) => {
+        impl ::std::fmt::Display for $type {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(f, "{:#x}", self.0)
+            }
+        }
+
+        #[cfg(feature = "with_serde")]
+        impl ::serde::ser::Serialize for $type {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: ::serde::ser::Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+    };
+}
+
+/// Helper macro to implement deserialization from both numeric values or their
+/// base16 (hex) / base10 representations as string. Implements `FromStr` and
+/// `Deserialize`.
+macro_rules! impl_hex_de {
+    ($type:ident, $num:ident) => {
+        impl ::std::str::FromStr for $type {
+            type Err = ::std::num::ParseIntError;
+
+            fn from_str(s: &str) -> Result<$type, ::std::num::ParseIntError> {
+                if s.starts_with("0x") || s.starts_with("0X") {
+                    $num::from_str_radix(&s[2..], 16).map($type)
+                } else {
+                    $num::from_str_radix(&s, 10).map($type)
+                }
+            }
+        }
+
+        #[cfg(feature = "with_serde")]
+        impl<'de> ::serde::de::Deserialize<'de> for $type {
+            fn deserialize<D>(deserializer: D) -> Result<$type, D::Error>
+            where
+                D: ::serde::de::Deserializer<'de>,
+            {
+                struct HexVisitor;
+
+                impl<'de> ::serde::de::Visitor<'de> for HexVisitor {
+                    type Value = $type;
+
+                    fn expecting(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                        write!(f, "a number or hex string")
+                    }
+
+                    fn visit_i64<E: ::serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                        Ok($type(v as $num))
+                    }
+
+                    fn visit_u64<E: ::serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                        Ok($type(v as $num))
+                    }
+
+                    fn visit_str<E: ::serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                        v.parse().map_err(::serde::de::Error::custom)
+                    }
+                }
+
+                deserializer.deserialize_any(HexVisitor)
+            }
+        }
+    };
+}
+
+/// Helper macro to implement serialization from both numeric values or their
+/// hex representation as string.
+///
+/// This implements `Serialize`, `Deserialize`, `Display` and `FromStr`.
+/// Serialization will always use a `"0xbeef"` representation of the value.
+/// Deserialization supports raw numbers as well as string representations
+/// in hex and base10.
+macro_rules! impl_hex_serde {
+    ($type:ident, $num:ident) => {
+        impl_hex_ser!($type);
+        impl_hex_de!($type, $num);
+    };
+}
+
+#[cfg(test)]
+mod hex_tests {
+    use serde_json;
+    use std::io::Cursor;
 
     #[derive(Debug, PartialEq)]
     struct Hex(u32);
 
-    impl_serde_hex!(Hex, u32);
+    impl_hex_serde!(Hex, u32);
 
     #[test]
     fn test_hex_to_string() {
@@ -181,6 +239,15 @@ mod tests {
         assert_eq!(
             Hex(42),
             serde_json::from_reader(Cursor::new("\"0X2A\"")).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_invalid() {
+        let result = serde_json::from_str::<Hex>("true").unwrap_err();
+        assert_eq!(
+            "invalid type: boolean `true`, expected a number or hex string at line 1 column 4",
+            result.to_string()
         );
     }
 }

--- a/src/project_id.rs
+++ b/src/project_id.rs
@@ -74,7 +74,7 @@ impl FromStr for ProjectId {
     }
 }
 
-impl_str_serialization!(ProjectId);
+impl_str_serde!(ProjectId);
 
 #[cfg(test)]
 mod test {

--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -21,20 +21,17 @@ use uuid::Uuid;
 
 use utils::{ts_seconds_float, ts_seconds_float_opt};
 
-/// An arbitrary (JSON) value (`serde_json::value::Value`)
+/// An arbitrary (JSON) value.
 pub mod value {
     pub use serde_json::value::{from_value, to_value, Index, Map, Number, Value};
 }
 
-/// The internally use arbitrary data map type (`linked_hash_map::LinkedHashMap`)
+/// The internally used arbitrary data map type.
 ///
 /// It is currently backed by the `linked-hash-map` crate's hash map so that
 /// insertion order is preserved.
 pub mod map {
-    pub use linked_hash_map::{
-        Entries, Entry, IntoIter, Iter, IterMut, Keys, LinkedHashMap, OccupiedEntry, VacantEntry,
-        Values,
-    };
+    pub use std::collections::hash_map::{HashMap as Map, *};
 }
 
 /// Represents a debug ID.
@@ -42,11 +39,11 @@ pub mod debugid {
     pub use debugid::{BreakpadFormat, DebugId, ParseDebugIdError};
 }
 
-/// An arbitrary (JSON) value (`serde_json::value::Value`)
+/// An arbitrary (JSON) value.
 pub use self::value::Value;
 
-/// The internally use arbitrary data map type (`linked_hash_map::LinkedHashMap`)
-pub use self::map::LinkedHashMap as Map;
+/// The internally useed map type.
+pub use self::map::Map;
 
 /// A wrapper type for collections with attached meta data.
 ///

--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -14,9 +14,7 @@ use std::str;
 
 use chrono::{DateTime, Utc};
 use debugid::DebugId;
-use serde::de::{Deserialize, Deserializer, Error as DeError};
-use serde::ser::{Error as SerError, Serialize, Serializer};
-use serde_json::{from_value, to_value};
+use serde::Serializer;
 use url::Url;
 use url_serde;
 use uuid::Uuid;
@@ -56,27 +54,21 @@ pub use self::map::LinkedHashMap as Map;
 /// arbitrary other fields. All other fields will be collected into `Values::data` when
 /// deserializing and re-serialized in the same place. The shorthand array notation is always
 /// reserialized as object.
-#[derive(Serialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Values<T> {
     /// The values of the collection.
     pub values: Vec<T>,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten, default)]
-    pub other: Map<String, Value>,
 }
 
 impl<T> Values<T> {
     /// Creates an empty values struct.
     pub fn new() -> Values<T> {
-        Values {
-            values: Vec::new(),
-            other: Map::new(),
-        }
+        Values { values: Vec::new() }
     }
 
     /// Checks whether this struct is empty in both values and data.
     pub fn is_empty(&self) -> bool {
-        self.values.is_empty() && self.other.is_empty()
+        self.values.is_empty()
     }
 }
 
@@ -89,10 +81,7 @@ impl<T> Default for Values<T> {
 
 impl<T> From<Vec<T>> for Values<T> {
     fn from(values: Vec<T>) -> Values<T> {
-        Values {
-            values,
-            other: Map::new(),
-        }
+        Values { values }
     }
 }
 
@@ -152,32 +141,6 @@ impl<T> IntoIterator for Values<T> {
     }
 }
 
-#[cfg(feature = "with_serde")]
-impl<'de, T> Deserialize<'de> for Values<T>
-where
-    T: Deserialize<'de>,
-{
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum Repr<T> {
-            Qualified {
-                values: Vec<T>,
-                #[serde(flatten)]
-                other: Map<String, Value>,
-            },
-            Unqualified(Vec<T>),
-            Single(T),
-        }
-
-        Deserialize::deserialize(deserializer).map(|x| match x {
-            Repr::Qualified { values, other } => Values { values, other },
-            Repr::Unqualified(values) => values.into(),
-            Repr::Single(value) => vec![value].into(),
-        })
-    }
-}
-
 /// Represents a log entry message.
 ///
 /// A log message is similar to the `message` attribute on the event itself but
@@ -189,9 +152,6 @@ pub struct LogEntry {
     /// Positional parameters to be inserted into the log entry.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub params: Vec<Value>,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten, default)]
-    pub other: Map<String, Value>,
 }
 
 /// Represents a frame.
@@ -238,9 +198,6 @@ pub struct Frame {
     /// Optional instruction information for native languages.
     #[serde(flatten)]
     pub instruction_info: InstructionInfo,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten)]
-    pub other: Map<String, Value>,
 }
 
 /// Represents location information.
@@ -283,9 +240,6 @@ pub struct TemplateInfo {
     /// Embedded sourcecode in the frame.
     #[serde(flatten)]
     pub source: EmbeddedSources,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten, default)]
-    pub other: Map<String, Value>,
 }
 
 /// Represents contextual information in a frame.
@@ -315,9 +269,6 @@ pub struct Stacktrace {
     /// Optional register values of the thread.
     #[serde(skip_serializing_if = "Map::is_empty")]
     pub registers: Map<String, RegVal>,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten)]
-    pub other: Map<String, Value>,
 }
 
 impl Stacktrace {
@@ -527,9 +478,6 @@ pub struct Thread {
     /// event was created.
     #[serde(skip_serializing_if = "is_false")]
     pub current: bool,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten)]
-    pub other: Map<String, Value>,
 }
 
 /// POSIX signal with optional extended data.
@@ -626,9 +574,6 @@ pub struct MechanismMeta {
     /// Optional mach exception information.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mach_exception: Option<MachException>,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten, default)]
-    pub other: Map<String, Value>,
 }
 
 impl MechanismMeta {
@@ -659,9 +604,6 @@ pub struct Mechanism {
     /// Operating system or runtime meta information.
     #[serde(skip_serializing_if = "MechanismMeta::is_empty")]
     pub meta: MechanismMeta,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten)]
-    pub other: Map<String, Value>,
 }
 
 /// Represents a single exception.
@@ -688,9 +630,6 @@ pub struct Exception {
     /// The mechanism of the exception including OS specific exception values.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mechanism: Option<Mechanism>,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten, default)]
-    pub other: Map<String, Value>,
 }
 
 /// An error used when parsing `Level`.
@@ -798,9 +737,6 @@ pub struct Breadcrumb {
     /// Arbitrary breadcrumb data that should be send along.
     #[serde(skip_serializing_if = "Map::is_empty")]
     pub data: Map<String, Value>,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten)]
-    pub other: Map<String, Value>,
 }
 
 impl Default for Breadcrumb {
@@ -812,7 +748,6 @@ impl Default for Breadcrumb {
             level: Level::Info,
             message: None,
             data: Map::new(),
-            other: Map::new(),
         }
     }
 }
@@ -876,19 +811,7 @@ impl str::FromStr for IpAddress {
     }
 }
 
-impl<'de> Deserialize<'de> for IpAddress {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<IpAddress, D::Error> {
-        <&str>::deserialize(deserializer)?
-            .parse()
-            .map_err(DeError::custom)
-    }
-}
-
-impl Serialize for IpAddress {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.to_string())
-    }
-}
+impl_str_serde!(IpAddress);
 
 /// Represents user info.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
@@ -906,9 +829,6 @@ pub struct User {
     /// A human readable username of the user.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten)]
-    pub other: Map<String, Value>,
 }
 
 /// Represents http request data.
@@ -937,9 +857,6 @@ pub struct Request {
     /// Optionally a CGI/WSGI etc. environment dictionary.
     #[serde(skip_serializing_if = "Map::is_empty")]
     pub env: Map<String, String>,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten)]
-    pub other: Map<String, Value>,
 }
 
 /// Holds information about the system SDK.
@@ -959,7 +876,8 @@ pub struct SystemSdkInfo {
 }
 
 /// Represents a debug image.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "type")]
 pub enum DebugImage {
     /// Apple debug images (machos).  This is currently also used for
     /// non apple platforms with similar debug setups.
@@ -968,8 +886,6 @@ pub enum DebugImage {
     Symbolic(SymbolicDebugImage),
     /// A reference to a proguard debug file.
     Proguard(ProguardDebugImage),
-    /// A debug image that is unknown to this protocol specification.
-    Unknown(Map<String, Value>),
 }
 
 impl DebugImage {
@@ -979,10 +895,6 @@ impl DebugImage {
             DebugImage::Apple(..) => "apple",
             DebugImage::Symbolic(..) => "symbolic",
             DebugImage::Proguard(..) => "proguard",
-            DebugImage::Unknown(ref map) => map
-                .get("type")
-                .and_then(|x| x.as_str())
-                .unwrap_or("unknown"),
         }
     }
 }
@@ -1058,9 +970,6 @@ pub struct DebugMeta {
     /// A list of debug information files.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub images: Vec<DebugImage>,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten)]
-    pub other: Map<String, Value>,
 }
 
 impl DebugMeta {
@@ -1110,8 +1019,216 @@ pub struct ClientSdkPackageInfo {
     pub version: String,
 }
 
+/// Typed contextual data.
+///
+/// Types like `OsContext` can be directly converted with `.into()`
+/// to `Context`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum Context {
+    /// Device data.
+    Device(Box<DeviceContext>),
+    /// Operating system data.
+    Os(Box<OsContext>),
+    /// Runtime data.
+    Runtime(Box<RuntimeContext>),
+    /// Application data.
+    App(Box<AppContext>),
+    /// Web browser data.
+    Browser(Box<BrowserContext>),
+}
+
+impl Context {
+    /// Returns the name of the type for sentry.
+    pub fn type_name(&self) -> &str {
+        match *self {
+            Context::Device(..) => "device",
+            Context::Os(..) => "os",
+            Context::Runtime(..) => "runtime",
+            Context::App(..) => "app",
+            Context::Browser(..) => "browser",
+        }
+    }
+}
+
+/// Optional device screen orientation
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum Orientation {
+    /// Portrait device orientation.
+    Portrait,
+    /// Landscape device orientation.
+    Landscape,
+}
+
+/// Holds device information.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[serde(default)]
+pub struct DeviceContext {
+    /// The name of the device.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The family of the device model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub family: Option<String>,
+    /// The device model (human readable).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// The device model (internal identifier).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    /// The native cpu architecture of the device.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arch: Option<String>,
+    /// The current battery level (0-100).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub battery_level: Option<f32>,
+    /// The current screen orientation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub orientation: Option<Orientation>,
+    /// Simulator/prod indicator.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub simulator: Option<bool>,
+    /// Total memory available in byts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_size: Option<u64>,
+    /// How much memory is still available in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub free_memory: Option<u64>,
+    /// How much memory is usable for the app in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usable_memory: Option<u64>,
+    /// Total storage size of the device in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_size: Option<u64>,
+    /// How much storage is free in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub free_storage: Option<u64>,
+    /// Total size of the attached external storage in bytes (eg: android SDK card).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_storage_size: Option<u64>,
+    /// Free size of the attached external storage in bytes (eg: android SDK card).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_free_storage: Option<u64>,
+    /// Optionally an indicator when the device was booted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub boot_time: Option<DateTime<Utc>>,
+    /// The timezone of the device.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+}
+
+/// Holds operating system information.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[serde(default)]
+pub struct OsContext {
+    /// The name of the operating system.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The version of the operating system.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// The internal build number of the operating system.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build: Option<String>,
+    /// The current kernel version.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernel_version: Option<String>,
+    /// An indicator if the os is rooted (mobile mostly).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rooted: Option<bool>,
+}
+
+/// Holds information about the runtime.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[serde(default)]
+pub struct RuntimeContext {
+    /// The name of the runtime (for instance JVM).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The version of the runtime.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+/// Holds app information.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[serde(default)]
+pub struct AppContext {
+    /// Optional start time of the app.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_start_time: Option<DateTime<Utc>>,
+    /// Optional device app hash (app specific device ID)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_app_hash: Option<String>,
+    /// Optional build identicator.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_type: Option<String>,
+    /// Optional app identifier (dotted bundle id).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_identifier: Option<String>,
+    /// Application name as it appears on the platform.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_name: Option<String>,
+    /// Application version as it appears on the platform.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_version: Option<String>,
+    /// Internal build ID as it appears on the platform.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_build: Option<String>,
+}
+
+/// Holds information about the web browser.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[serde(default)]
+pub struct BrowserContext {
+    /// The name of the browser (for instance "Chrome").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The version of the browser.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+macro_rules! into_context {
+    ($kind:ident, $ty:ty) => {
+        impl From<$ty> for Context {
+            fn from(data: $ty) -> Self {
+                Context::$kind(Box::new(data))
+            }
+        }
+    };
+}
+
+into_context!(App, AppContext);
+into_context!(Device, DeviceContext);
+into_context!(Os, OsContext);
+into_context!(Runtime, RuntimeContext);
+into_context!(Browser, BrowserContext);
+
+fn is_other(value: &str) -> bool {
+    value == "other"
+}
+
+fn serialize_event_id<S>(value: &Option<Uuid>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match *value {
+        Some(ref uuid) => serializer.serialize_some(&uuid.simple().to_string()),
+        None => serializer.serialize_none(),
+    }
+}
+
+static DEFAULT_FINGERPRINT: &'static [Cow<'static, str>] = &[Cow::Borrowed("{{ default }}")];
+
+#[cfg_attr(feature = "cargo-clippy", allow(ptr_arg))]
+fn is_default_fingerprint<'a>(fp: &Cow<'a, [Cow<'a, str>]>) -> bool {
+    fp.len() == 1 && ((&fp)[0] == "{{ default }}" || (&fp)[0] == "{{default}}")
+}
+
 /// Represents a full event for Sentry.
-#[derive(Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(default)]
 pub struct Event<'a> {
     /// The ID of the event
@@ -1176,7 +1293,7 @@ pub struct Event<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request: Option<Request>,
     /// Optional contexts.
-    #[serde(skip_serializing_if = "Map::is_empty", with = "serde_context")]
+    #[serde(skip_serializing_if = "Map::is_empty")]
     pub contexts: Map<String, Context>,
     /// List of breadcrumbs to send along.
     #[serde(skip_serializing_if = "Values::is_empty")]
@@ -1205,241 +1322,6 @@ pub struct Event<'a> {
     /// SDK metadata
     #[serde(rename = "sdk", skip_serializing_if = "Option::is_none")]
     pub sdk_info: Option<Cow<'a, ClientSdkInfo>>,
-    /// Additional arbitrary fields for forwards compatibility.
-    #[serde(flatten)]
-    pub other: Map<String, Value>,
-}
-
-#[cfg(feature = "with_serde")]
-impl<'a, 'de> Deserialize<'de> for Event<'a> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        /// A lenient representation of the `Event` struct used for aliasing field names.
-        #[derive(Deserialize)]
-        #[serde(default)]
-        pub struct LenientEvent<'a> {
-            #[serde(rename = "event_id")]
-            pub id: Option<Uuid>,
-            pub level: Level,
-            #[serde(deserialize_with = "deserialize_fingerprint")]
-            pub fingerprint: Cow<'a, [Cow<'a, str>]>,
-            pub culprit: Option<String>,
-            pub transaction: Option<String>,
-            pub message: Option<String>,
-            pub logentry: Option<LogEntry>,
-            #[serde(rename = "sentry.interfaces.Message")]
-            pub logentry_iface: Option<LogEntry>,
-            pub logger: Option<String>,
-            pub modules: Map<String, String>,
-            pub platform: Cow<'a, str>,
-            #[serde(with = "ts_seconds_float_opt")]
-            pub timestamp: Option<DateTime<Utc>>,
-            pub server_name: Option<Cow<'a, str>>,
-            pub release: Option<Cow<'a, str>>,
-            pub dist: Option<Cow<'a, str>>,
-            pub repos: Map<String, RepoReference>,
-            pub environment: Option<Cow<'a, str>>,
-            pub user: Option<User>,
-            #[serde(rename = "sentry.interfaces.User")]
-            pub user_iface: Option<User>,
-            pub request: Option<Request>,
-            #[serde(rename = "sentry.interfaces.Http")]
-            pub request_iface: Option<Request>,
-            #[serde(with = "serde_context")]
-            pub contexts: Map<String, Context>,
-            #[serde(with = "serde_context", rename = "sentry.interfaces.Contexts")]
-            pub contexts_iface: Map<String, Context>,
-            pub breadcrumbs: Option<Values<Breadcrumb>>,
-            #[serde(rename = "sentry.interfaces.Breadcrumbs")]
-            pub breadcrumbs_iface: Option<Values<Breadcrumb>>,
-            #[serde(rename = "exception")]
-            pub exceptions: Option<Values<Exception>>,
-            #[serde(rename = "sentry.interfaces.Exception")]
-            pub exceptions_iface: Option<Values<Exception>>,
-            pub stacktrace: Option<Stacktrace>,
-            #[serde(rename = "sentry.interfaces.Stacktrace")]
-            pub stacktrace_iface: Option<Stacktrace>,
-            #[serde(rename = "template")]
-            pub template_info: Option<TemplateInfo>,
-            #[serde(rename = "sentry.interfaces.Template")]
-            pub template_info_iface: Option<TemplateInfo>,
-            pub threads: Option<Values<Thread>>,
-            #[serde(rename = "sentry.interfaces.Threads")]
-            pub threads_iface: Option<Values<Thread>>,
-            pub tags: Map<String, String>,
-            pub extra: Map<String, Value>,
-            pub debug_meta: Cow<'a, DebugMeta>,
-            #[serde(rename = "sentry.interfaces.DebugMeta")]
-            pub debug_meta_iface: Cow<'a, DebugMeta>,
-            #[serde(rename = "sdk")]
-            pub sdk_info: Option<Cow<'a, ClientSdkInfo>>,
-            #[serde(flatten)]
-            pub other: Map<String, Value>,
-        }
-
-        impl<'a> Default for LenientEvent<'a> {
-            fn default() -> LenientEvent<'a> {
-                let default = Event::default();
-
-                LenientEvent {
-                    id: default.id,
-                    level: default.level,
-                    fingerprint: default.fingerprint,
-                    culprit: default.culprit,
-                    transaction: default.transaction,
-                    message: default.message,
-                    logentry: default.logentry,
-                    logentry_iface: None,
-                    logger: default.logger,
-                    modules: default.modules,
-                    platform: default.platform,
-                    timestamp: default.timestamp,
-                    server_name: default.server_name,
-                    release: default.release,
-                    dist: default.dist,
-                    repos: default.repos,
-                    environment: default.environment,
-                    user: None,
-                    user_iface: default.user,
-                    request: default.request,
-                    request_iface: None,
-                    contexts: default.contexts,
-                    contexts_iface: Default::default(),
-                    breadcrumbs: None,
-                    breadcrumbs_iface: None,
-                    exceptions: None,
-                    exceptions_iface: None,
-                    stacktrace: default.stacktrace,
-                    stacktrace_iface: None,
-                    template_info: default.template_info,
-                    template_info_iface: None,
-                    threads: None,
-                    threads_iface: None,
-                    tags: default.tags,
-                    extra: default.extra,
-                    debug_meta: default.debug_meta,
-                    debug_meta_iface: Default::default(),
-                    sdk_info: default.sdk_info,
-                    other: default.other,
-                }
-            }
-        }
-
-        impl<'a> From<LenientEvent<'a>> for Event<'a> {
-            fn from(lenient: LenientEvent) -> Event {
-                Event {
-                    id: lenient.id,
-                    level: lenient.level,
-                    fingerprint: lenient.fingerprint,
-                    culprit: lenient.culprit,
-                    transaction: lenient.transaction,
-                    message: lenient.message,
-                    logentry: lenient.logentry.or(lenient.logentry_iface),
-                    logger: lenient.logger,
-                    modules: lenient.modules,
-                    platform: lenient.platform,
-                    timestamp: lenient.timestamp,
-                    server_name: lenient.server_name,
-                    release: lenient.release,
-                    dist: lenient.dist,
-                    repos: lenient.repos,
-                    environment: lenient.environment,
-                    user: lenient.user.or(lenient.user_iface),
-                    request: lenient.request.or(lenient.request_iface),
-                    contexts: if lenient.contexts.is_empty() {
-                        lenient.contexts_iface
-                    } else {
-                        lenient.contexts
-                    },
-                    breadcrumbs: lenient
-                        .breadcrumbs
-                        .or(lenient.breadcrumbs_iface)
-                        .unwrap_or_default(),
-                    exceptions: lenient
-                        .exceptions
-                        .or(lenient.exceptions_iface)
-                        .unwrap_or_default(),
-                    stacktrace: lenient.stacktrace.or(lenient.stacktrace_iface),
-                    template_info: lenient.template_info.or(lenient.template_info_iface),
-                    threads: lenient
-                        .threads
-                        .or(lenient.threads_iface)
-                        .unwrap_or_default(),
-                    tags: lenient.tags,
-                    extra: lenient.extra,
-                    debug_meta: if lenient.debug_meta.is_empty() {
-                        lenient.debug_meta_iface
-                    } else {
-                        lenient.debug_meta
-                    },
-                    sdk_info: lenient.sdk_info,
-                    other: lenient.other,
-                }
-            }
-        }
-
-        Ok(LenientEvent::deserialize(deserializer)?.into())
-    }
-}
-
-fn is_other(value: &str) -> bool {
-    value == "other"
-}
-
-static DEFAULT_FINGERPRINT: &'static [Cow<'static, str>] = &[Cow::Borrowed("{{ default }}")];
-
-#[cfg_attr(feature = "cargo-clippy", allow(ptr_arg))]
-fn is_default_fingerprint<'a>(fp: &Cow<'a, [Cow<'a, str>]>) -> bool {
-    fp.len() == 1 && ((&fp)[0] == "{{ default }}" || (&fp)[0] == "{{default}}")
-}
-
-/// Deserializes fingerprints into a list of strings.
-fn deserialize_fingerprint<'a, 'de, D>(deserializer: D) -> Result<Cow<'a, [Cow<'a, str>]>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    #[derive(Debug, Deserialize)]
-    #[serde(untagged)]
-    enum Fingerprint {
-        Bool(bool),
-        Number(value::Number),
-        String(String),
-    }
-
-    impl Into<Option<Cow<'static, str>>> for Fingerprint {
-        fn into(self) -> Option<Cow<'static, str>> {
-            match self {
-                Fingerprint::Bool(b) => Some(if b { "True" } else { "False" }.into()),
-                Fingerprint::Number(n) => {
-                    if let Some(u) = n.as_u64() {
-                        Some(u.to_string().into())
-                    } else if let Some(i) = n.as_i64() {
-                        Some(i.to_string().into())
-                    } else if let Some(f) = n.as_f64() {
-                        if f.abs() < (1i64 << 53) as f64 {
-                            Some(f.trunc().to_string().into())
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                }
-                Fingerprint::String(s) => Some(s.into()),
-            }
-        }
-    }
-
-    let value = Value::deserialize(deserializer)?;
-    Ok(
-        if let Ok(fingerprint) = from_value::<Vec<Fingerprint>>(value) {
-            Cow::Owned(fingerprint.into_iter().filter_map(|f| f.into()).collect())
-        } else {
-            Cow::Borrowed(DEFAULT_FINGERPRINT)
-        },
-    )
 }
 
 impl<'a> Default for Event<'a> {
@@ -1473,7 +1355,6 @@ impl<'a> Default for Event<'a> {
             extra: Map::new(),
             debug_meta: Default::default(),
             sdk_info: None,
-            other: Map::new(),
         }
     }
 }
@@ -1523,7 +1404,6 @@ impl<'a> Event<'a> {
             extra: self.extra,
             debug_meta: Cow::Owned(self.debug_meta.into_owned()),
             sdk_info: self.sdk_info.map(|x| Cow::Owned(x.into_owned())),
-            other: self.other,
         }
     }
 }
@@ -1538,402 +1418,5 @@ impl<'a> fmt::Display for Event<'a> {
             write!(f, ", ts: {}", ts)?;
         }
         write!(f, ")")
-    }
-}
-
-/// Optional device screen orientation
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
-#[serde(rename_all = "lowercase")]
-pub enum Orientation {
-    /// Portrait device orientation.
-    Portrait,
-    /// Landscape device orientation.
-    Landscape,
-}
-
-/// General context data.
-///
-/// The data can be either typed (`ContextData`) or be filled in as
-/// unhandled attributes in `extra`.  If completely arbitrary data
-/// should be used the typed data can be set to `ContextData::Default`
-/// in which case no key is well known.
-///
-/// Types like `OsContext` can be directly converted with `.into()`
-/// to `Context` or `ContextData`.
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct Context {
-    /// Typed context data.
-    pub data: ContextData,
-    /// Additional arbitrary fields for forwards compatibility.
-    pub other: Map<String, Value>,
-}
-
-/// Typed contextual data
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "snake_case", untagged)]
-pub enum ContextData {
-    /// Arbitrary contextual information
-    Default,
-    /// Device data.
-    Device(Box<DeviceContext>),
-    /// Operating system data.
-    Os(Box<OsContext>),
-    /// Runtime data.
-    Runtime(Box<RuntimeContext>),
-    /// Application data.
-    App(Box<AppContext>),
-    /// Web browser data.
-    Browser(Box<BrowserContext>),
-}
-
-/// Holds device information.
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
-pub struct DeviceContext {
-    /// The name of the device.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    /// The family of the device model.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub family: Option<String>,
-    /// The device model (human readable).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
-    /// The device model (internal identifier).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub model_id: Option<String>,
-    /// The native cpu architecture of the device.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub arch: Option<String>,
-    /// The current battery level (0-100).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub battery_level: Option<f32>,
-    /// The current screen orientation.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub orientation: Option<Orientation>,
-    /// Simulator/prod indicator.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub simulator: Option<bool>,
-    /// Total memory available in byts.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub memory_size: Option<u64>,
-    /// How much memory is still available in bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub free_memory: Option<u64>,
-    /// How much memory is usable for the app in bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub usable_memory: Option<u64>,
-    /// Total storage size of the device in bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub storage_size: Option<u64>,
-    /// How much storage is free in bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub free_storage: Option<u64>,
-    /// Total size of the attached external storage in bytes (eg: android SDK card).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub external_storage_size: Option<u64>,
-    /// Free size of the attached external storage in bytes (eg: android SDK card).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub external_free_storage: Option<u64>,
-    /// Optionally an indicator when the device was booted.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub boot_time: Option<DateTime<Utc>>,
-    /// The timezone of the device.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timezone: Option<String>,
-}
-
-/// Holds operating system information.
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
-pub struct OsContext {
-    /// The name of the operating system.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    /// The version of the operating system.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-    /// The internal build number of the operating system.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub build: Option<String>,
-    /// The current kernel version.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub kernel_version: Option<String>,
-    /// An indicator if the os is rooted (mobile mostly).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rooted: Option<bool>,
-}
-
-/// Holds information about the runtime.
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
-pub struct RuntimeContext {
-    /// The name of the runtime (for instance JVM).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    /// The version of the runtime.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-}
-
-/// Holds app information.
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
-pub struct AppContext {
-    /// Optional start time of the app.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub app_start_time: Option<DateTime<Utc>>,
-    /// Optional device app hash (app specific device ID)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub device_app_hash: Option<String>,
-    /// Optional build identicator.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub build_type: Option<String>,
-    /// Optional app identifier (dotted bundle id).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub app_identifier: Option<String>,
-    /// Application name as it appears on the platform.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub app_name: Option<String>,
-    /// Application version as it appears on the platform.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub app_version: Option<String>,
-    /// Internal build ID as it appears on the platform.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub app_build: Option<String>,
-}
-
-/// Holds information about the web browser.
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
-pub struct BrowserContext {
-    /// The name of the browser (for instance "Chrome").
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    /// The version of the browser.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-}
-
-impl From<ContextData> for Context {
-    fn from(data: ContextData) -> Context {
-        Context {
-            data,
-            other: Map::new(),
-        }
-    }
-}
-
-macro_rules! into_context {
-    ($kind:ident, $ty:ty) => {
-        impl From<$ty> for ContextData {
-            fn from(data: $ty) -> ContextData {
-                ContextData::$kind(Box::new(data))
-            }
-        }
-
-        impl From<$ty> for Context {
-            fn from(data: $ty) -> Context {
-                ContextData::$kind(Box::new(data)).into()
-            }
-        }
-    };
-}
-
-into_context!(App, AppContext);
-into_context!(Device, DeviceContext);
-into_context!(Os, OsContext);
-into_context!(Runtime, RuntimeContext);
-into_context!(Browser, BrowserContext);
-
-impl From<Map<String, Value>> for Context {
-    fn from(data: Map<String, Value>) -> Context {
-        Context {
-            data: ContextData::Default,
-            other: data,
-        }
-    }
-}
-
-impl Default for ContextData {
-    fn default() -> ContextData {
-        ContextData::Default
-    }
-}
-
-impl ContextData {
-    /// Returns the name of the type for sentry.
-    pub fn type_name(&self) -> &str {
-        match *self {
-            ContextData::Default => "default",
-            ContextData::Device(..) => "device",
-            ContextData::Os(..) => "os",
-            ContextData::Runtime(..) => "runtime",
-            ContextData::App(..) => "app",
-            ContextData::Browser(..) => "browser",
-        }
-    }
-}
-
-fn serialize_event_id<S>(value: &Option<Uuid>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    if let Some(ref uuid) = *value {
-        serializer.serialize_some(&uuid.simple().to_string())
-    } else {
-        serializer.serialize_none()
-    }
-}
-
-#[cfg(feature = "with_serde")]
-mod serde_context {
-    use std::str;
-
-    use serde::de::{Deserialize, Deserializer, Error as DeError};
-    use serde::ser::{Error as SerError, SerializeMap, Serializer};
-    use serde_json::{from_value, to_value};
-
-    use super::{
-        value, AppContext, BrowserContext, Context, ContextData, DeviceContext, Map, OsContext,
-        RuntimeContext, Value,
-    };
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Map<String, Context>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let raw = <Map<String, Value>>::deserialize(deserializer)?;
-        let mut rv = Map::new();
-
-        #[derive(Deserialize)]
-        pub struct Helper<T> {
-            #[serde(flatten)]
-            data: T,
-            #[serde(flatten)]
-            other: Map<String, Value>,
-        }
-
-        for (key, raw_context) in raw {
-            let (ty, data) = match raw_context {
-                Value::Object(mut map) => {
-                    let has_type = if let Some(&Value::String(..)) = map.get("type") {
-                        true
-                    } else {
-                        false
-                    };
-                    let ty = if has_type {
-                        map.remove("type")
-                            .and_then(|x| x.as_str().map(|x| x.to_string()))
-                            .unwrap()
-                    } else {
-                        key.to_string()
-                    };
-                    (ty, Value::Object(map))
-                }
-                _ => continue,
-            };
-
-            macro_rules! convert_context {
-                ($enum:path, $ty:ident) => {{
-                    let helper = from_value::<Helper<$ty>>(data).map_err(D::Error::custom)?;
-                    ($enum(Box::new(helper.data)), helper.other)
-                }};
-            }
-
-            let (data, other) = match ty.as_str() {
-                "device" => convert_context!(ContextData::Device, DeviceContext),
-                "os" => convert_context!(ContextData::Os, OsContext),
-                "runtime" => convert_context!(ContextData::Runtime, RuntimeContext),
-                "app" => convert_context!(ContextData::App, AppContext),
-                "browser" => convert_context!(ContextData::Browser, BrowserContext),
-                _ => (
-                    ContextData::Default,
-                    from_value(data).map_err(D::Error::custom)?,
-                ),
-            };
-            rv.insert(key, Context { data, other });
-        }
-
-        Ok(rv)
-    }
-
-    pub fn serialize<S>(value: &Map<String, Context>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut map = try!(serializer.serialize_map(None));
-
-        for (key, value) in value {
-            let mut c = if let ContextData::Default = value.data {
-                value::Map::new()
-            } else {
-                match to_value(&value.data).map_err(S::Error::custom)? {
-                    Value::Object(map) => map,
-                    _ => unreachable!(),
-                }
-            };
-            c.insert("type".into(), value.data.type_name().into());
-            c.extend(
-                value
-                    .other
-                    .iter()
-                    .map(|(key, value)| (key.to_string(), value.clone())),
-            );
-            try!(map.serialize_entry(key, &c));
-        }
-
-        map.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for DebugImage {
-    fn deserialize<D>(deserializer: D) -> Result<DebugImage, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let mut map = match Value::deserialize(deserializer)? {
-            Value::Object(map) => map,
-            _ => return Err(D::Error::custom("expected debug image")),
-        };
-
-        Ok(match map.remove("type").as_ref().and_then(|x| x.as_str()) {
-            Some("apple") => {
-                let img: AppleDebugImage =
-                    from_value(Value::Object(map)).map_err(D::Error::custom)?;
-                DebugImage::Apple(img)
-            }
-            Some("symbolic") => {
-                let img: SymbolicDebugImage =
-                    from_value(Value::Object(map)).map_err(D::Error::custom)?;
-                DebugImage::Symbolic(img)
-            }
-            Some("proguard") => {
-                let img: ProguardDebugImage =
-                    from_value(Value::Object(map)).map_err(D::Error::custom)?;
-                DebugImage::Proguard(img)
-            }
-            Some(ty) => {
-                let mut img: Map<String, Value> = map.into_iter().collect();
-                img.insert("type".into(), ty.into());
-                DebugImage::Unknown(img)
-            }
-            None => DebugImage::Unknown(Default::default()),
-        })
-    }
-}
-
-impl Serialize for DebugImage {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let actual = match *self {
-            DebugImage::Apple(ref img) => to_value(img),
-            DebugImage::Symbolic(ref img) => to_value(img),
-            DebugImage::Proguard(ref img) => to_value(img),
-            DebugImage::Unknown(ref img) => to_value(img),
-        };
-        let mut c = match actual.map_err(S::Error::custom)? {
-            Value::Object(map) => map,
-            _ => unreachable!(),
-        };
-        c.insert("type".into(), self.type_name().into());
-        c.serialize(serializer)
     }
 }

--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -407,7 +407,7 @@ impl Addr {
     }
 }
 
-impl_serde_hex!(Addr, u64);
+impl_hex_serde!(Addr, u64);
 
 impl From<u64> for Addr {
     fn from(addr: u64) -> Addr {
@@ -459,7 +459,7 @@ fn is_false(value: &bool) -> bool {
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct RegVal(pub u64);
 
-impl_serde_hex!(RegVal, u64);
+impl_hex_serde!(RegVal, u64);
 
 impl From<u64> for RegVal {
     fn from(addr: u64) -> RegVal {
@@ -773,7 +773,7 @@ impl Level {
     }
 }
 
-impl_str_serialization!(Level);
+impl_str_serde!(Level);
 
 /// Represents a single breadcrumb.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -31,7 +31,7 @@ pub mod value {
 /// It is currently backed by the `linked-hash-map` crate's hash map so that
 /// insertion order is preserved.
 pub mod map {
-    pub use std::collections::hash_map::{HashMap as Map, *};
+    pub use std::collections::btree_map::{BTreeMap as Map, *};
 }
 
 /// Represents a debug ID.

--- a/tests/test_protocol_v7.rs
+++ b/tests/test_protocol_v7.rs
@@ -368,9 +368,6 @@ mod test_user {
         let event = v7::Event {
             user: Some(v7::User {
                 id: Some("8fd5a33b-5b0e-45b2-aff2-9e4f067756ba".into()),
-                email: None,
-                ip_address: None,
-                username: None,
                 ..Default::default()
             }),
             ..Default::default()
@@ -635,7 +632,6 @@ mod test_request {
                     env.insert("PATH_INFO".into(), "/bar".into());
                     env
                 },
-                ..Default::default()
             }),
             ..Default::default()
         };
@@ -983,7 +979,6 @@ mod test_exception {
                         m.insert("x12".into(), v7::RegVal(0x1_b3b3_7b1d));
                         m
                     },
-                    ..Default::default()
                 }),
                 raw_stacktrace: Some(v7::Stacktrace {
                     frames: vec![v7::Frame {

--- a/tests/test_protocol_v7.rs
+++ b/tests/test_protocol_v7.rs
@@ -166,72 +166,6 @@ mod test_fingerprint {
     }
 
     #[test]
-    fn test_fingerprint_bool() {
-        assert_eq!(
-            v7::Event {
-                fingerprint: Cow::Borrowed(&["True".into(), "False".into()]),
-                ..Default::default()
-            },
-            serde_json::from_str("{\"fingerprint\":[true, false]}").unwrap()
-        )
-    }
-
-    #[test]
-    fn test_fingerprint_number() {
-        assert_eq!(
-            v7::Event {
-                fingerprint: Cow::Borrowed(&["-22".into()]),
-                ..Default::default()
-            },
-            serde_json::from_str("{\"fingerprint\":[-22]}").unwrap()
-        )
-    }
-
-    #[test]
-    fn test_fingerprint_float() {
-        assert_eq!(
-            v7::Event {
-                fingerprint: Cow::Borrowed(&["3".into()]),
-                ..Default::default()
-            },
-            serde_json::from_str("{\"fingerprint\":[3.0]}").unwrap()
-        )
-    }
-
-    #[test]
-    fn test_fingerprint_float_trunc() {
-        assert_eq!(
-            v7::Event {
-                fingerprint: Cow::Borrowed(&["3".into()]),
-                ..Default::default()
-            },
-            serde_json::from_str("{\"fingerprint\":[3.5]}").unwrap()
-        )
-    }
-
-    #[test]
-    fn test_fingerprint_float_strip() {
-        assert_eq!(
-            v7::Event {
-                fingerprint: Cow::Borrowed(&[]),
-                ..Default::default()
-            },
-            serde_json::from_str("{\"fingerprint\":[-1e100]}").unwrap()
-        )
-    }
-
-    #[test]
-    fn test_fingerprint_invalid_fallback() {
-        assert_eq!(
-            v7::Event {
-                fingerprint: Cow::Borrowed(&["{{ default }}".into()]),
-                ..Default::default()
-            },
-            serde_json::from_str("{\"fingerprint\":[\"a\",null,\"d\"]}").unwrap()
-        )
-    }
-
-    #[test]
     fn test_fingerprint_empty() {
         assert_eq!(
             v7::Event {
@@ -241,41 +175,15 @@ mod test_fingerprint {
             serde_json::from_str("{\"fingerprint\":[]}").unwrap()
         )
     }
-
-    #[test]
-    fn test_fingerprint_float_bounds() {
-        assert_eq!(
-            v7::Event {
-                fingerprint: Cow::Borrowed(&[]),
-                ..Default::default()
-            },
-            serde_json::from_str("{\"fingerprint\":[1.7976931348623157e+308]}").unwrap()
-        )
-    }
 }
 
 mod test_values {
     use super::*;
 
     #[test]
-    fn test_values_array() {
-        let values = v7::Values {
-            values: vec![1, 2, 3],
-            other: v7::Map::new(),
-        };
-
-        assert_eq!(values, serde_json::from_str("[1,2,3]").unwrap());
-        assert_eq!(
-            serde_json::to_string(&values).unwrap(),
-            "{\"values\":[1,2,3]}".to_string()
-        );
-    }
-
-    #[test]
     fn test_values_object() {
         let values = v7::Values {
             values: vec![1, 2, 3],
-            other: v7::Map::new(),
         };
 
         assert_eq!(
@@ -286,28 +194,6 @@ mod test_values {
         assert_eq!(
             serde_json::to_string(&values).unwrap(),
             "{\"values\":[1,2,3]}".to_string()
-        );
-    }
-
-    #[test]
-    fn test_values_additional_data() {
-        let values = v7::Values {
-            values: vec![1, 2, 3],
-            other: {
-                let mut m = v7::Map::new();
-                m.insert("foo".into(), "bar".into());
-                m
-            },
-        };
-
-        assert_eq!(
-            values,
-            serde_json::from_str("{\"values\":[1,2,3],\"foo\":\"bar\"}").unwrap()
-        );
-
-        assert_eq!(
-            serde_json::to_string(&values).unwrap(),
-            "{\"values\":[1,2,3],\"foo\":\"bar\"}".to_string()
         );
     }
 
@@ -335,7 +221,6 @@ mod test_logentry {
             logentry: Some(v7::LogEntry {
                 message: "Hello %s!".to_string(),
                 params: vec!["World".into()],
-                other: Default::default(),
             }),
             culprit: Some("foo in bar".to_string()),
             level: v7::Level::Debug,
@@ -355,7 +240,6 @@ mod test_logentry {
             logentry: Some(v7::LogEntry {
                 message: "Hello World!".to_string(),
                 params: vec![],
-                other: Default::default(),
             }),
             ..Default::default()
         };
@@ -363,22 +247,6 @@ mod test_logentry {
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
             "{\"logentry\":{\"message\":\"Hello World!\"}}"
-        );
-    }
-
-    #[test]
-    fn test_logentry_interface() {
-        assert_eq!(
-            v7::Event {
-                logentry: Some(v7::LogEntry {
-                    message: "Hello World!".to_string(),
-                    params: vec![],
-                    other: Default::default(),
-                }),
-                ..Default::default()
-            },
-            serde_json::from_str("{\"sentry.interfaces.Message\":{\"message\":\"Hello World!\"}}")
-                .unwrap()
         );
     }
 }
@@ -523,11 +391,6 @@ mod test_user {
                 email: Some("foo@example.invalid".into()),
                 ip_address: Some("127.0.0.1".parse().unwrap()),
                 username: Some("john-doe".into()),
-                other: {
-                    let mut hm = v7::Map::new();
-                    hm.insert("foo".into(), "bar".into());
-                    hm
-                },
             }),
             ..Default::default()
         };
@@ -537,7 +400,7 @@ mod test_user {
             serde_json::to_string(&event).unwrap(),
             "{\"user\":{\"id\":\"8fd5a33b-5b0e-45b2-aff2-9e4f067756ba\",\
              \"email\":\"foo@example.invalid\",\"ip_address\":\"127.0.0.1\",\
-             \"username\":\"john-doe\",\"foo\":\"bar\"}}"
+             \"username\":\"john-doe\"}}"
         );
     }
 
@@ -555,25 +418,6 @@ mod test_user {
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
             "{\"user\":{\"ip_address\":\"{{auto}}\"}}"
-        );
-    }
-
-    #[test]
-    fn test_user_interface() {
-        assert_eq!(
-            v7::Event {
-                user: Some(v7::User {
-                    id: Some("8fd5a33b-5b0e-45b2-aff2-9e4f067756ba".into()),
-                    email: None,
-                    ip_address: None,
-                    username: None,
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-            serde_json::from_str(
-                "{\"sentry.interfaces.User\":{\"id\":\"8fd5a33b-5b0e-45b2-aff2-9e4f067756ba\"}}"
-            ).unwrap()
         );
     }
 }
@@ -610,20 +454,6 @@ mod test_breadcrumbs {
     }
 
     #[test]
-    fn test_breadcrumbs_list() {
-        let event = event();
-        assert_eq!(
-            event,
-            serde_json::from_str(
-                "{\"breadcrumbs\":[{\"timestamp\":1514103120.713,\"type\":\"default\",\
-                 \"category\":\"ui.click\",\"message\":\"span.platform-card > li.platform-tile\"\
-                 },{\"timestamp\":1514103120.913,\"type\":\"http\",\"category\":\"xhr\",\"data\"\
-                 :{\"url\":\"/api/0/organizations/foo\",\"status_code\":200,\"method\":\"GET\"}}]}"
-            ).unwrap()
-        );
-    }
-
-    #[test]
     fn test_breadcrumbs_values() {
         let event = event();
         assert_roundtrip(&event);
@@ -632,21 +462,7 @@ mod test_breadcrumbs {
             "{\"breadcrumbs\":{\"values\":[{\"timestamp\":1514103120.713,\"type\":\"default\",\
              \"category\":\"ui.click\",\"message\":\"span.platform-card > li.platform-tile\"\
              },{\"timestamp\":1514103120.913,\"type\":\"http\",\"category\":\"xhr\",\"data\"\
-             :{\"url\":\"/api/0/organizations/foo\",\"status_code\":200,\"method\":\"GET\"}}]}}"
-        );
-    }
-
-    #[test]
-    fn test_breadcrumbs_interface() {
-        let event = event();
-        assert_eq!(
-            event,
-            serde_json::from_str(
-                "{\"sentry.interfaces.Breadcrumbs\":[{\"timestamp\":1514103120.713,\"type\":\"default\",\
-                \"category\":\"ui.click\",\"message\":\"span.platform-card > li.platform-tile\"\
-                },{\"timestamp\":1514103120.913,\"type\":\"http\",\"category\":\"xhr\",\"data\"\
-                :{\"url\":\"/api/0/organizations/foo\",\"status_code\":200,\"method\":\"GET\"}}]}"
-            ).unwrap()
+             :{\"method\":\"GET\",\"status_code\":200,\"url\":\"/api/0/organizations/foo\"}}]}}"
         );
     }
 }
@@ -679,31 +495,6 @@ mod test_stacktrace {
              \"filename\":\"hello.py\",\"lineno\":1}]}}"
         );
     }
-
-    #[test]
-    fn test_stacktrace_interface() {
-        assert_eq!(
-            v7::Event {
-                stacktrace: Some(v7::Stacktrace {
-                    frames: vec![v7::Frame {
-                        function: Some("main".into()),
-                        location: v7::FileLocation {
-                            filename: Some("hello.py".into()),
-                            line: Some(1),
-                            ..Default::default()
-                        },
-                        ..Default::default()
-                    }],
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-            serde_json::from_str(
-                "{\"sentry.interfaces.Stacktrace\":{\"frames\":[{\"function\":\"main\",\
-                 \"filename\":\"hello.py\",\"lineno\":1}]}}",
-            ).unwrap()
-        )
-    }
 }
 
 mod test_template_info {
@@ -723,7 +514,6 @@ mod test_template_info {
                     current_line: Some("hey hey hey3".into()),
                     post_lines: vec!["foo4".into(), "bar5".into()],
                 },
-                other: Default::default(),
             }),
             ..Default::default()
         };
@@ -735,33 +525,6 @@ mod test_template_info {
              \"pre_context\":[\"foo1\",\"bar2\"],\"context_line\":\
              \"hey hey hey3\",\"post_context\":[\"foo4\",\"bar5\"]}}"
         );
-    }
-
-    #[test]
-    fn test_template_info_interface() {
-        assert_eq!(
-            v7::Event {
-                template_info: Some(v7::TemplateInfo {
-                    location: v7::FileLocation {
-                        filename: Some("hello.html".into()),
-                        line: Some(1),
-                        ..Default::default()
-                    },
-                    source: v7::EmbeddedSources {
-                        pre_lines: vec!["foo1".into(), "bar2".into()],
-                        current_line: Some("hey hey hey3".into()),
-                        post_lines: vec!["foo4".into(), "bar5".into()],
-                    },
-                    other: Default::default(),
-                }),
-                ..Default::default()
-            },
-            serde_json::from_str(
-                "{\"sentry.interfaces.Template\":{\"filename\":\"hello.html\",\"lineno\":1,\
-                 \"pre_context\":[\"foo1\",\"bar2\"],\"context_line\":\
-                 \"hey hey hey3\",\"post_context\":[\"foo4\",\"bar5\"]}}",
-            ).unwrap()
-        )
     }
 }
 
@@ -783,43 +546,6 @@ mod test_threads {
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
             "{\"threads\":{\"values\":[{\"id\":\"#1\",\"name\":\"Awesome Thread\"}]}}"
-        );
-    }
-
-    #[test]
-    fn test_threads_list() {
-        let event = v7::Event {
-            threads: vec![v7::Thread {
-                id: Some("#1".into()),
-                name: Some("Awesome Thread".into()),
-                ..Default::default()
-            }].into(),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            event,
-            serde_json::from_str("{\"threads\":[{\"id\":\"#1\",\"name\":\"Awesome Thread\"}]}")
-                .unwrap()
-        );
-    }
-
-    #[test]
-    fn test_threads_interface() {
-        let event = v7::Event {
-            threads: vec![v7::Thread {
-                id: Some("#1".into()),
-                name: Some("Awesome Thread".into()),
-                ..Default::default()
-            }].into(),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            event,
-            serde_json::from_str(
-                "{\"sentry.interfaces.Threads\":[{\"id\":\"#1\",\"name\":\"Awesome Thread\"}]}"
-            ).unwrap()
         );
     }
 
@@ -934,11 +660,6 @@ mod test_request {
                 data: Some("{}".into()),
                 query_string: Some("foo=bar&blub=blah".into()),
                 cookies: Some("dummy=42".into()),
-                other: {
-                    let mut m = v7::Map::new();
-                    m.insert("other_key".into(), "other_value".into());
-                    m
-                },
                 ..Default::default()
             }),
             ..Default::default()
@@ -949,8 +670,7 @@ mod test_request {
             serde_json::to_string(&event).unwrap(),
             "{\"request\":{\"url\":\"https://www.example.invalid/bar\",\
              \"method\":\"GET\",\"data\":\"{}\",\"query_string\":\
-             \"foo=bar&blub=blah\",\"cookies\":\"dummy=42\",\
-             \"other_key\":\"other_value\"}}"
+             \"foo=bar&blub=blah\",\"cookies\":\"dummy=42\"}}"
         );
     }
 
@@ -963,17 +683,6 @@ mod test_request {
 
         assert_roundtrip(&event);
         assert_eq!(serde_json::to_string(&event).unwrap(), "{\"request\":{}}");
-    }
-
-    #[test]
-    fn test_request_interface() {
-        assert_eq!(
-            v7::Event {
-                request: Some(Default::default()),
-                ..Default::default()
-            },
-            serde_json::from_str("{\"sentry.interfaces.Http\":{}}").unwrap()
-        )
     }
 }
 
@@ -1047,28 +756,6 @@ mod test_debug_meta {
     }
 
     #[test]
-    fn test_debug_meta_interface() {
-        assert_eq!(
-            v7::Event {
-                debug_meta: Cow::Owned(v7::DebugMeta {
-                    sdk_info: Some(v7::SystemSdkInfo {
-                        sdk_name: "iOS".into(),
-                        version_major: 10,
-                        version_minor: 3,
-                        version_patchlevel: 0,
-                    }),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-            serde_json::from_str(
-                "{\"sentry.interfaces.DebugMeta\":{\"sdk_info\":{\"sdk_name\":\"iOS\",\
-                 \"version_major\":10,\"version_minor\":3,\"version_patchlevel\":0}}}"
-            ).unwrap()
-        );
-    }
-
-    #[test]
     fn test_debug_meta_images() {
         let event = v7::Event {
             debug_meta: Cow::Owned(v7::DebugMeta {
@@ -1103,51 +790,20 @@ mod test_debug_meta {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"debug_meta\":{\"images\":[{\"name\":\"CoreFoundation\",\"arch\":\
+            "{\"debug_meta\":{\"images\":[{\"type\":\"apple\",\"name\":\"CoreFoundation\",\"arch\":\
              \"arm64\",\"cpu_type\":1233,\"cpu_subtype\":3,\"image_addr\":\"0x0\",\
              \"image_size\":4096,\"image_vmaddr\":\"0x8000\",\"uuid\":\
-             \"494f3aea-88fa-4296-9644-fa8ef5d139b6\",\"type\":\"apple\"},\
-             {\"name\":\"CoreFoundation\",\"arch\":\"arm64\",\"image_addr\":\
+             \"494f3aea-88fa-4296-9644-fa8ef5d139b6\"},\
+             {\"type\":\"symbolic\",\"name\":\"CoreFoundation\",\"arch\":\"arm64\",\"image_addr\":\
              \"0x0\",\"image_size\":4096,\"image_vmaddr\":\"0x8000\",\"id\":\
-             \"494f3aea-88fa-4296-9644-fa8ef5d139b6-1234\",\"type\":\"symbolic\"}\
-             ,{\"uuid\":\"8c954262-f905-4992-8a61-f60825f4553b\",\"type\":\"proguard\"}]}}"
+             \"494f3aea-88fa-4296-9644-fa8ef5d139b6-1234\"},\
+             {\"type\":\"proguard\",\"uuid\":\"8c954262-f905-4992-8a61-f60825f4553b\"}]}}"
         );
     }
 }
 
 mod test_exception {
     use super::*;
-
-    #[test]
-    fn test_exception_null() {
-        let event: v7::Event = serde_json::from_slice(b"{\"exception\":null}").unwrap();
-        assert_eq!(event.exceptions, Default::default());
-    }
-
-    #[test]
-    fn test_exception_single() {
-        let json = "{\"exception\":{\"type\":\"ZeroDivisionError\"}}";
-        let event: v7::Event = serde_json::from_str(&json).unwrap();
-        let mut ref_event: v7::Event = Default::default();
-        ref_event.exceptions.values.push(v7::Exception {
-            ty: "ZeroDivisionError".into(),
-            ..Default::default()
-        });
-        assert_eq!(event, ref_event);
-    }
-
-    #[test]
-    fn test_exception_list() {
-        let json = "{\"exception\":[{\"type\":\"ZeroDivisionError\"}]}";
-        let event: v7::Event = serde_json::from_str(&json).unwrap();
-        let mut ref_event: v7::Event = Default::default();
-        ref_event.exceptions.values.push(v7::Exception {
-            ty: "ZeroDivisionError".into(),
-            ..Default::default()
-        });
-        assert_roundtrip(&event);
-        assert_eq!(event, ref_event);
-    }
 
     #[test]
     fn test_exception_values() {
@@ -1165,31 +821,6 @@ mod test_exception {
 
         let event2: v7::Event = serde_json::from_str(&json).unwrap();
         assert_eq!(event, event2);
-    }
-
-    #[test]
-    fn test_exception_interface() {
-        let json = "{\"sentry.interfaces.Exception\":{\"type\":\"ZeroDivisionError\"}}";
-        let event: v7::Event = serde_json::from_str(&json).unwrap();
-        let mut ref_event: v7::Event = Default::default();
-        ref_event.exceptions.values.push(v7::Exception {
-            ty: "ZeroDivisionError".into(),
-            ..Default::default()
-        });
-        assert_eq!(event, ref_event);
-    }
-
-    #[test]
-    fn test_exception_precedence() {
-        let json = "{\"exception\":{\"type\":\"ZeroDivisionError\"},\
-                    \"sentry.interfaces.Exception\":{\"type\":\"WRONG\"}}";
-        let event: v7::Event = serde_json::from_str(&json).unwrap();
-        let mut ref_event: v7::Event = Default::default();
-        ref_event.exceptions.values.push(v7::Exception {
-            ty: "ZeroDivisionError".into(),
-            ..Default::default()
-        });
-        assert_eq!(event, ref_event);
     }
 
     #[test]
@@ -1311,11 +942,6 @@ mod test_exception {
                             instruction_addr: Some(v7::Addr(0)),
                             symbol_addr: Some(v7::Addr(0)),
                         },
-                        other: {
-                            let mut m = v7::Map::new();
-                            m.insert("zzz".into(), "foo".into());
-                            m
-                        },
                     }],
                     frames_omitted: Some((1, 2)),
                     registers: {
@@ -1387,20 +1013,19 @@ mod test_exception {
              :\"/app/hello.py\",\"lineno\":7,\"colno\":42,\"pre_context\":[\"foo\",\"\
              bar\"],\"context_line\":\"hey hey hey\",\"post_context\":[\"foo\",\"bar\"]\
              ,\"in_app\":true,\"vars\":{\"var\":\"value\"},\"image_addr\":\"0x0\",\
-             \"instruction_addr\":\"0x0\",\"symbol_addr\":\"0x0\",\"zzz\":\"foo\"}],\"frames_omitted\":\
-             [1,2],\"registers\":{\"x8\":\"0x0\",\"x20\":\"0x1\",\"x21\":\"0x1\",\"x28\
-             \":\"0x17025f650\",\"x4\":\"0x1702eb100\",\"x24\":\"0x1b1399c20\",\"sp\":\
-             \"0x16fd75060\",\"x1\":\"0x1b1399bb1\",\"x23\":\"0x1afe10040\",\"x14\":\
-             \"0x1\",\"x19\":\"0x0\",\"x18\":\"0x0\",\"x3\":\"0x1\",\"pc\":\"0x18a310ea4\
-             \",\"x7\":\"0x0\",\"x10\":\"0x57b\",\"x6\":\"0x0\",\"x13\":\"0x1\",\"x2\":\
-             \"0x1\",\"x27\":\"0x1\",\"x26\":\"0x191ec48d1\",\"x9\":\"0x1b1399c20\",\
-             \"x29\":\"0x16fd75060\",\"x5\":\"0x1702eb100\",\"fp\":\"0x16fd75060\",\
-             \"x0\":\"0x1\",\"lr\":\"0x18a31aadc\",\"x25\":\"0x0\",\"x16\":\
-             \"0x18a31aa34\",\"x11\":\"0x1b3b37b1d\",\"cpsr\":\"0x20000000\",\"x17\":\
-             \"0x0\",\"x15\":\"0x881\",\"x22\":\"0x1b1399bb0\",\"x12\":\"0x1b3b37b1d\"}\
-             },\"raw_stacktrace\":{\"frames\":[{\"function\":\"main\",\"image_addr\":\
-             \"0x0\",\"instruction_addr\":\"0x0\",\"symbol_addr\":\"0x0\"}],\
-             \"frames_omitted\":[1,2]}}]}}"
+             \"instruction_addr\":\"0x0\",\"symbol_addr\":\"0x0\"}],\"frames_omitted\":\
+             [1,2],\"registers\":{\"cpsr\":\"0x20000000\",\"fp\":\"0x16fd75060\",\"lr\":\
+             \"0x18a31aadc\",\"pc\":\"0x18a310ea4\",\"sp\":\"0x16fd75060\",\"x0\":\"0x1\",\
+             \"x1\":\"0x1b1399bb1\",\"x10\":\"0x57b\",\"x11\":\"0x1b3b37b1d\",\"x12\":\
+             \"0x1b3b37b1d\",\"x13\":\"0x1\",\"x14\":\"0x1\",\"x15\":\"0x881\",\"x16\":\
+             \"0x18a31aa34\",\"x17\":\"0x0\",\"x18\":\"0x0\",\"x19\":\"0x0\",\"x2\":\"0x1\"\
+             ,\"x20\":\"0x1\",\"x21\":\"0x1\",\"x22\":\"0x1b1399bb0\",\"x23\":\"0x1afe10040\"\
+             ,\"x24\":\"0x1b1399c20\",\"x25\":\"0x0\",\"x26\":\"0x191ec48d1\",\"x27\":\"0x1\",\
+             \"x28\":\"0x17025f650\",\"x29\":\"0x16fd75060\",\"x3\":\"0x1\",\"x4\":\
+             \"0x1702eb100\",\"x5\":\"0x1702eb100\",\"x6\":\"0x0\",\"x7\":\"0x0\",\"x8\":\
+             \"0x0\",\"x9\":\"0x1b1399c20\"}},\"raw_stacktrace\":{\"frames\":[{\"function\":\
+             \"main\",\"image_addr\":\"0x0\",\"instruction_addr\":\"0x0\",\"symbol_addr\":\
+             \"0x0\"}],\"frames_omitted\":[1,2]}}]}}"
         );
     }
 
@@ -1441,9 +1066,7 @@ mod test_exception {
                             subcode: 8,
                             name: None,
                         }),
-                        other: Default::default(),
                     },
-                    other: Default::default(),
                 }),
                 ..Default::default()
             }].into(),
@@ -1490,20 +1113,13 @@ fn test_sdk_info() {
 fn test_other_data() {
     let event = v7::Event {
         id: Some("864ee979-77bf-43ac-96d7-4f7486d138ab".parse().unwrap()),
-        other: {
-            let mut m = v7::Map::new();
-            m.insert("extra_shit".into(), 42.into());
-            m.insert("extra_garbage".into(), "aha".into());
-            m
-        },
         ..Default::default()
     };
 
     assert_roundtrip(&event);
     assert_eq!(
         serde_json::to_string(&event).unwrap(),
-        "{\"event_id\":\"864ee97977bf43ac96d74f7486d138ab\",\
-         \"extra_shit\":42,\"extra_garbage\":\"aha\"}"
+        "{\"event_id\":\"864ee97977bf43ac96d74f7486d138ab\"}"
     );
 }
 
@@ -1545,13 +1161,13 @@ mod test_contexts {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"device\":{\"name\":\"iphone\",\"family\":\"iphone\",\"model\":\
+            "{\"contexts\":{\"device\":{\"type\":\"device\",\"name\":\"iphone\",\"family\":\"iphone\",\"model\":\
              \"iphone7,3\",\"model_id\":\"AH223\",\"arch\":\"arm64\",\"battery_level\":58.5,\
              \"orientation\":\"landscape\",\"simulator\":true,\"memory_size\":3137978368,\
              \"free_memory\":322781184,\"usable_memory\":2843525120,\"storage_size\":63989469184,\
              \"free_storage\":31994734592,\"external_storage_size\":2097152,\
              \"external_free_storage\":2097152,\"boot_time\":\"2018-02-08T12:52:12Z\",\"timezone\":\
-             \"Europe/Vienna\",\"type\":\"device\"}}}"
+             \"Europe/Vienna\"}}}"
         );
     }
 
@@ -1578,8 +1194,8 @@ mod test_contexts {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"os\":{\"name\":\"iOS\",\"version\":\"11.4.2\",\"build\":\"ADSA23\",\
-             \"kernel_version\":\"17.4.0\",\"rooted\":true,\"type\":\"os\"}}}"
+            "{\"contexts\":{\"os\":{\"type\":\"os\",\"name\":\"iOS\",\"version\":\"11.4.2\",\
+             \"build\":\"ADSA23\",\"kernel_version\":\"17.4.0\",\"rooted\":true}}}"
         );
     }
 
@@ -1608,10 +1224,10 @@ mod test_contexts {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"app\":{\"app_start_time\":\"2018-02-08T22:21:57Z\",\
+            "{\"contexts\":{\"app\":{\"type\":\"app\",\"app_start_time\":\"2018-02-08T22:21:57Z\",\
              \"device_app_hash\":\"4c793e3776474877ae30618378e9662a\",\"build_type\":\
              \"testflight\",\"app_identifier\":\"foo.bar.baz\",\"app_name\":\"Baz App\",\
-             \"app_version\":\"1.0\",\"app_build\":\"100001\",\"type\":\"app\"}}}"
+             \"app_version\":\"1.0\",\"app_build\":\"100001\"}}}"
         );
     }
 
@@ -1635,8 +1251,8 @@ mod test_contexts {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"browser\":{\"name\":\"Chrome\",\"version\":\"59.0.3071\",\"type\":\
-             \"browser\"}}}"
+            "{\"contexts\":{\"browser\":{\"type\":\"browser\",\"name\":\"Chrome\",\"version\":\
+             \"59.0.3071\"}}}"
         );
     }
 
@@ -1660,33 +1276,8 @@ mod test_contexts {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"runtime\":{\"name\":\"magicvm\",\"version\":\"5.3\",\"type\":\
-             \"runtime\"}}}"
-        );
-    }
-
-    #[test]
-    fn test_unknown_context() {
-        let event = v7::Event {
-            contexts: {
-                let mut m = v7::Map::new();
-                m.insert(
-                    "other".into(),
-                    {
-                        let mut m = v7::Map::new();
-                        m.insert("aha".into(), "oho".into());
-                        m
-                    }.into(),
-                );
-                m
-            },
-            ..Default::default()
-        };
-
-        assert_roundtrip(&event);
-        assert_eq!(
-            serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"other\":{\"type\":\"default\",\"aha\":\"oho\"}}}"
+            "{\"contexts\":{\"runtime\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\
+             \"5.3\"}}}"
         );
     }
 
@@ -1704,17 +1295,10 @@ mod test_contexts {
                 );
                 m.insert(
                     "othervm".into(),
-                    v7::Context {
-                        data: v7::RuntimeContext {
-                            name: Some("magicvm".into()),
-                            version: Some("5.3".into()),
-                        }.into(),
-                        other: {
-                            let mut m = v7::Map::new();
-                            m.insert("extra_stuff".into(), "extra_value".into());
-                            m
-                        },
-                    },
+                    v7::RuntimeContext {
+                        name: Some("magicvm".into()),
+                        version: Some("5.3".into()),
+                    }.into(),
                 );
                 m
             },
@@ -1724,25 +1308,8 @@ mod test_contexts {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"magicvm\":{\"name\":\"magicvm\",\"version\":\"5.3\",\"type\":\
-             \"runtime\"},\"othervm\":{\"name\":\"magicvm\",\"version\":\"5.3\",\"type\":\
-             \"runtime\",\"extra_stuff\":\"extra_value\"}}}"
-        );
-    }
-
-    #[test]
-    fn test_contexts_interface() {
-        assert_eq!(
-            v7::Event {
-                contexts: {
-                    let mut m = v7::Map::new();
-                    m.insert("os".into(), v7::OsContext::default().into());
-                    m
-                },
-                ..Default::default()
-            },
-            serde_json::from_str("{\"sentry.interfaces.Contexts\":{\"os\":{\"type\":\"os\"}}}")
-                .unwrap()
+            "{\"contexts\":{\"magicvm\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\
+             \"5.3\"},\"othervm\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\"5.3\"}}}"
         );
     }
 }


### PR DESCRIPTION
This PR removes all custom deserializers for lenient v7 Events. It keeps
deserialization, however, in the most strict way.