### PR TITLE
ref(protocol): Align protocol with other SDKs

### DIFF
--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -19,7 +19,7 @@ use url::Url;
 use url_serde;
 use uuid::Uuid;
 
-use utils::{ts_seconds_float, ts_seconds_float_opt};
+use utils::ts_seconds_float;
 
 /// An arbitrary (JSON) value.
 pub mod value {
@@ -70,14 +70,14 @@ impl<T> Values<T> {
 }
 
 impl<T> Default for Values<T> {
-    fn default() -> Values<T> {
+    fn default() -> Self {
         // Default implemented manually even if <T> does not impl Default.
         Values::new()
     }
 }
 
 impl<T> From<Vec<T>> for Values<T> {
-    fn from(values: Vec<T>) -> Values<T> {
+    fn from(values: Vec<T>) -> Self {
         Values { values }
     }
 }
@@ -147,124 +147,113 @@ pub struct LogEntry {
     /// The log message with parameters replaced by `%s`
     pub message: String,
     /// Positional parameters to be inserted into the log entry.
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub params: Vec<Value>,
 }
 
 /// Represents a frame.
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
-#[serde(default)]
 pub struct Frame {
     /// The name of the function is known.
     ///
     /// Note that this might include the name of a class as well if that makes
     /// sense for the language.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub function: Option<String>,
     /// The potentially mangled name of the symbol as it appears in an executable.
     ///
     /// This is different from a function name by generally being the mangled
     /// name that appears natively in the binary.  This is relevant for languages
     /// like Swift, C++ or Rust.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub symbol: Option<String>,
     /// The name of the module the frame is contained in.
     ///
     /// Note that this might also include a class name if that is something the
     /// language natively considers to be part of the stack (for instance in Java).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub module: Option<String>,
     /// The name of the package that contains the frame.
     ///
     /// For instance this can be a dylib for native languages, the name of the jar
     /// or .NET assembly.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package: Option<String>,
-    /// Location information about where the error originated.
-    #[serde(flatten)]
-    pub location: FileLocation,
-    /// Embedded sourcecode in the frame.
-    #[serde(flatten)]
-    pub source: EmbeddedSources,
-    /// In-app indicator.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub in_app: Option<bool>,
-    /// Optional local variables.
-    #[serde(skip_serializing_if = "Map::is_empty")]
-    pub vars: Map<String, Value>,
-    /// Optional instruction information for native languages.
-    #[serde(flatten)]
-    pub instruction_info: InstructionInfo,
-}
-
-/// Represents location information.
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
-pub struct FileLocation {
     /// The filename (basename only).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub filename: Option<String>,
     /// If known the absolute path.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub abs_path: Option<String>,
     /// The line number if known.
-    #[serde(rename = "lineno", skip_serializing_if = "Option::is_none")]
-    pub line: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lineno: Option<u64>,
     /// The column number if known.
-    #[serde(rename = "colno", skip_serializing_if = "Option::is_none")]
-    pub column: Option<u64>,
-}
-
-/// Represents instruction information.
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
-pub struct InstructionInfo {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub colno: Option<u64>,
+    /// The sources of the lines leading up to the current line.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pre_context: Vec<String>,
+    /// The current line as source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_line: Option<String>,
+    /// The sources of the lines after the current line.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub post_context: Vec<String>,
+    /// In-app indicator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_app: Option<bool>,
+    /// Optional local variables.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub vars: Map<String, Value>,
     /// If known the location of the image.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_addr: Option<Addr>,
     /// If known the location of the instruction.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instruction_addr: Option<Addr>,
     /// If known the location of symbol.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub symbol_addr: Option<Addr>,
 }
 
 /// Represents template debug info.
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
 pub struct TemplateInfo {
-    /// Location information about where the error originated.
-    #[serde(flatten)]
-    pub location: FileLocation,
-    /// Embedded sourcecode in the frame.
-    #[serde(flatten)]
-    pub source: EmbeddedSources,
-}
-
-/// Represents contextual information in a frame.
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
-#[serde(default)]
-pub struct EmbeddedSources {
+    /// The filename (basename only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    /// If known the absolute path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub abs_path: Option<String>,
+    /// The line number if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lineno: Option<u64>,
+    /// The column number if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub colno: Option<u64>,
     /// The sources of the lines leading up to the current line.
-    #[serde(rename = "pre_context", skip_serializing_if = "Vec::is_empty")]
-    pub pre_lines: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pre_context: Vec<String>,
     /// The current line as source.
-    #[serde(rename = "context_line", skip_serializing_if = "Option::is_none")]
-    pub current_line: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_line: Option<String>,
     /// The sources of the lines after the current line.
-    #[serde(rename = "post_context", skip_serializing_if = "Vec::is_empty")]
-    pub post_lines: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub post_context: Vec<String>,
 }
 
 /// Represents a stacktrace.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
-#[serde(default)]
 pub struct Stacktrace {
     /// The list of frames in the stacktrace.
+    #[serde(default)]
     pub frames: Vec<Frame>,
     /// Optionally a segment of frames removed (`start`, `end`).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub frames_omitted: Option<(u64, u64)>,
     /// Optional register values of the thread.
-    #[serde(skip_serializing_if = "Map::is_empty")]
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub registers: Map<String, RegVal>,
 }
 
@@ -453,27 +442,26 @@ impl Into<u64> for RegVal {
 
 /// Represents a single thread.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
-#[serde(default)]
 pub struct Thread {
     /// The optional ID of the thread (usually an integer)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<ThreadId>,
     /// The optional name of the thread.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// If the thread suspended or crashed a stacktrace can be
     /// attached here.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stacktrace: Option<Stacktrace>,
     /// Optional raw stacktrace.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_stacktrace: Option<Stacktrace>,
     /// True if this is the crashed thread.
-    #[serde(skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub crashed: bool,
     /// Indicates that the thread was not suspended when the
     /// event was created.
-    #[serde(skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub current: bool,
 }
 
@@ -483,7 +471,7 @@ pub struct CError {
     /// The error code as specified by ISO C99, POSIX.1-2001 or POSIX.1-2008.
     pub number: i32,
     /// Optional name of the errno constant.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -503,14 +491,13 @@ impl Into<i32> for CError {
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct MachException {
     /// The mach exception type.
-    #[serde(rename = "exception")]
-    pub ty: i32,
+    pub exception: i32,
     /// The mach exception code.
     pub code: u64,
     /// The mach exception subcode.
     pub subcode: u64,
     /// Optional name of the mach exception.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -520,13 +507,13 @@ pub struct PosixSignal {
     /// The POSIX signal number.
     pub number: i32,
     /// An optional signal code present on Apple systems.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code: Option<i32>,
     /// Optional name of the errno constant.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// Optional name of the errno constant.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code_name: Option<String>,
 }
 
@@ -563,13 +550,13 @@ impl Into<i32> for PosixSignal {
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct MechanismMeta {
     /// Optional ISO C standard error code.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub errno: Option<CError>,
     /// Optional POSIX signal number.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signal: Option<PosixSignal>,
     /// Optional mach exception information.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mach_exception: Option<MachException>,
 }
 
@@ -581,25 +568,24 @@ impl MechanismMeta {
 
 /// Represents a single exception.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
-#[serde(default)]
 pub struct Mechanism {
     /// The mechanism type identifier.
     #[serde(rename = "type")]
     pub ty: String,
     /// Human readable detail description.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// An optional link to online resources describing this error.
-    #[serde(with = "url_serde", skip_serializing_if = "Option::is_none")]
+    #[serde(default, with = "url_serde", skip_serializing_if = "Option::is_none")]
     pub help_link: Option<Url>,
     /// An optional flag indicating whether this exception was handled.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub handled: Option<bool>,
     /// Additional attributes depending on the mechanism type.
-    #[serde(skip_serializing_if = "Map::is_empty")]
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub data: Map<String, Value>,
     /// Operating system or runtime meta information.
-    #[serde(skip_serializing_if = "MechanismMeta::is_empty")]
+    #[serde(default, skip_serializing_if = "MechanismMeta::is_empty")]
     pub meta: MechanismMeta,
 }
 
@@ -613,19 +599,19 @@ pub struct Exception {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
     /// An optional module for this exception.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub module: Option<String>,
     /// Optionally the stacktrace.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stacktrace: Option<Stacktrace>,
     /// An optional raw stacktrace.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_stacktrace: Option<Stacktrace>,
     /// Optional identifier referring to a thread.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thread_id: Option<ThreadId>,
     /// The mechanism of the exception including OS specific exception values.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mechanism: Option<Mechanism>,
 }
 
@@ -711,40 +697,63 @@ impl Level {
 
 impl_str_serde!(Level);
 
+mod breadcrumb {
+    use super::*;
+
+    pub fn default_timestamp() -> DateTime<Utc> {
+        Utc::now()
+    }
+
+    pub fn default_type() -> String {
+        "default".to_string()
+    }
+
+    pub fn is_default_type(ty: &str) -> bool {
+        ty == "default"
+    }
+
+    pub fn default_level() -> Level {
+        Level::Info
+    }
+}
+
 /// Represents a single breadcrumb.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(default)]
 pub struct Breadcrumb {
     /// The timestamp of the breadcrumb.  This is required.
-    #[serde(with = "ts_seconds_float")]
+    #[serde(default = "breadcrumb::default_timestamp", with = "ts_seconds_float")]
     pub timestamp: DateTime<Utc>,
     /// The type of the breadcrumb.
-    #[serde(rename = "type")]
+    #[serde(
+        rename = "type",
+        default = "breadcrumb::default_type",
+        skip_serializing_if = "breadcrumb::is_default_type"
+    )]
     pub ty: String,
     /// The optional category of the breadcrumb.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub category: Option<String>,
     /// The non optional level of the breadcrumb.  It
     /// defaults to info.
-    #[serde(skip_serializing_if = "Level::is_info")]
+    #[serde(default = "breadcrumb::default_level", skip_serializing_if = "Level::is_info")]
     pub level: Level,
     /// An optional human readbale message for the breadcrumb.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     /// Arbitrary breadcrumb data that should be send along.
-    #[serde(skip_serializing_if = "Map::is_empty")]
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub data: Map<String, Value>,
 }
 
 impl Default for Breadcrumb {
     fn default() -> Breadcrumb {
         Breadcrumb {
-            timestamp: Utc::now(),
-            ty: "default".into(),
-            category: None,
-            level: Level::Info,
-            message: None,
-            data: Map::new(),
+            timestamp: breadcrumb::default_timestamp(),
+            ty: breadcrumb::default_type(),
+            category: Default::default(),
+            level: breadcrumb::default_level(),
+            message: Default::default(),
+            data: Default::default(),
         }
     }
 }
@@ -812,47 +821,45 @@ impl_str_serde!(IpAddress);
 
 /// Represents user info.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
-#[serde(default)]
 pub struct User {
     /// The ID of the user.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// The email address of the user.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
     /// The remote ip address of the user.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ip_address: Option<IpAddress>,
     /// A human readable username of the user.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
 }
 
 /// Represents http request data.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
-#[serde(default)]
 pub struct Request {
     /// The current URL of the request.
-    #[serde(with = "url_serde", skip_serializing_if = "Option::is_none")]
+    #[serde(default, with = "url_serde", skip_serializing_if = "Option::is_none")]
     pub url: Option<Url>,
     /// The HTTP request method.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub method: Option<String>,
     /// Optionally some associated request data (human readable)
     // XXX: this makes absolutely no sense because of unicode
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
     /// Optionally the encoded query string.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub query_string: Option<String>,
     /// An encoded cookie string if available.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cookies: Option<String>,
     /// HTTP request headers.
-    #[serde(skip_serializing_if = "Map::is_empty")]
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub headers: Map<String, String>,
     /// Optionally a CGI/WSGI etc. environment dictionary.
-    #[serde(skip_serializing_if = "Map::is_empty")]
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub env: Map<String, String>,
 }
 
@@ -922,7 +929,7 @@ pub struct AppleDebugImage {
     /// The size of the image in bytes.
     pub image_size: u64,
     /// The address where the image is loaded at runtime.
-    #[serde(skip_serializing_if = "Addr::is_null")]
+    #[serde(default, skip_serializing_if = "Addr::is_null")]
     pub image_vmaddr: Addr,
     /// The unique UUID of the image.
     pub uuid: Uuid,
@@ -940,7 +947,7 @@ pub struct SymbolicDebugImage {
     /// The size of the image in bytes.
     pub image_size: u64,
     /// The address where the image is loaded at runtime.
-    #[serde(skip_serializing_if = "Addr::is_null")]
+    #[serde(default, skip_serializing_if = "Addr::is_null")]
     pub image_vmaddr: Addr,
     /// The unique debug id of the image.
     pub id: DebugId,
@@ -959,13 +966,12 @@ into_debug_image!(Proguard, ProguardDebugImage);
 
 /// Represents debug meta information.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
-#[serde(default)]
 pub struct DebugMeta {
     /// Optional system SDK information.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sdk_info: Option<SystemSdkInfo>,
     /// A list of debug information files.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub images: Vec<DebugImage>,
 }
 
@@ -985,10 +991,10 @@ pub struct RepoReference {
     pub name: String,
     /// The optional prefix path to apply to source code when pairing it
     /// up with files in the repository.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
     /// The optional current revision of the local repository.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<String>,
 }
 
@@ -1000,10 +1006,10 @@ pub struct ClientSdkInfo {
     /// The version of the SDK.
     pub version: String,
     /// An optional list of integrations that are enabled in this SDK.
-    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub integrations: Vec<String>,
     /// An optional list of packages that are installed in the SDK's environment.
-    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub packages: Vec<ClientSdkPackageInfo>,
 }
 
@@ -1060,130 +1066,125 @@ pub enum Orientation {
 
 /// Holds device information.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
-#[serde(default)]
 pub struct DeviceContext {
     /// The name of the device.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// The family of the device model.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub family: Option<String>,
     /// The device model (human readable).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     /// The device model (internal identifier).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_id: Option<String>,
     /// The native cpu architecture of the device.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub arch: Option<String>,
     /// The current battery level (0-100).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub battery_level: Option<f32>,
     /// The current screen orientation.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub orientation: Option<Orientation>,
     /// Simulator/prod indicator.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub simulator: Option<bool>,
     /// Total memory available in byts.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory_size: Option<u64>,
     /// How much memory is still available in bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub free_memory: Option<u64>,
     /// How much memory is usable for the app in bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usable_memory: Option<u64>,
     /// Total storage size of the device in bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_size: Option<u64>,
     /// How much storage is free in bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub free_storage: Option<u64>,
     /// Total size of the attached external storage in bytes (eg: android SDK card).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_storage_size: Option<u64>,
     /// Free size of the attached external storage in bytes (eg: android SDK card).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_free_storage: Option<u64>,
     /// Optionally an indicator when the device was booted.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub boot_time: Option<DateTime<Utc>>,
     /// The timezone of the device.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
 }
 
 /// Holds operating system information.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
-#[serde(default)]
 pub struct OsContext {
     /// The name of the operating system.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// The version of the operating system.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
     /// The internal build number of the operating system.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build: Option<String>,
     /// The current kernel version.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kernel_version: Option<String>,
     /// An indicator if the os is rooted (mobile mostly).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rooted: Option<bool>,
 }
 
 /// Holds information about the runtime.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
-#[serde(default)]
 pub struct RuntimeContext {
     /// The name of the runtime (for instance JVM).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// The version of the runtime.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 }
 
 /// Holds app information.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
-#[serde(default)]
 pub struct AppContext {
     /// Optional start time of the app.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_start_time: Option<DateTime<Utc>>,
     /// Optional device app hash (app specific device ID)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub device_app_hash: Option<String>,
     /// Optional build identicator.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build_type: Option<String>,
     /// Optional app identifier (dotted bundle id).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_identifier: Option<String>,
     /// Application name as it appears on the platform.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_name: Option<String>,
     /// Application version as it appears on the platform.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_version: Option<String>,
     /// Internal build ID as it appears on the platform.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_build: Option<String>,
 }
 
 /// Holds information about the web browser.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
-#[serde(default)]
 pub struct BrowserContext {
     /// The name of the browser (for instance "Chrome").
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// The version of the browser.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 }
 
@@ -1203,155 +1204,173 @@ into_context!(Os, OsContext);
 into_context!(Runtime, RuntimeContext);
 into_context!(Browser, BrowserContext);
 
-fn is_other(value: &str) -> bool {
-    value == "other"
-}
+mod event {
+    use super::*;
 
-fn serialize_event_id<S>(value: &Option<Uuid>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    match *value {
-        Some(ref uuid) => serializer.serialize_some(&uuid.simple().to_string()),
-        None => serializer.serialize_none(),
+    pub fn default_id() -> Uuid {
+        Uuid::new_v4()
     }
-}
 
-static DEFAULT_FINGERPRINT: &'static [Cow<'static, str>] = &[Cow::Borrowed("{{ default }}")];
+    pub fn serialize_id<S: Serializer>(uuid: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_some(&uuid.simple().to_string())
+    }
 
-#[cfg_attr(feature = "cargo-clippy", allow(ptr_arg))]
-fn is_default_fingerprint<'a>(fp: &Cow<'a, [Cow<'a, str>]>) -> bool {
-    fp.len() == 1 && ((&fp)[0] == "{{ default }}" || (&fp)[0] == "{{default}}")
+    pub fn default_level() -> Level {
+        Level::Error
+    }
+
+    pub fn default_platform() -> Cow<'static, str> {
+        Cow::Borrowed("other")
+    }
+
+    pub fn is_default_platform(value: &str) -> bool {
+        value == "other"
+    }
+
+    static DEFAULT_FINGERPRINT: &[Cow<'static, str>] = &[Cow::Borrowed("{{ default }}")];
+
+    pub fn default_fingerprint<'a>() -> Cow<'a, [Cow<'a, str>]> {
+        Cow::Borrowed(DEFAULT_FINGERPRINT)
+    }
+
+    #[cfg_attr(feature = "cargo-clippy", allow(ptr_arg))]
+    pub fn is_default_fingerprint<'a>(fp: &[Cow<'a, str>]) -> bool {
+        fp.len() == 1 && ((&fp)[0] == "{{ default }}" || (&fp)[0] == "{{default}}")
+    }
+
+    pub fn default_timestamp() -> DateTime<Utc> {
+        Utc::now()
+    }
 }
 
 /// Represents a full event for Sentry.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(default)]
 pub struct Event<'a> {
     /// The ID of the event
-    #[serde(
-        serialize_with = "serialize_event_id",
-        rename = "event_id",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub id: Option<Uuid>,
+    #[serde(default = "event::default_id", serialize_with = "event::serialize_id")]
+    pub event_id: Uuid,
     /// The level of the event (defaults to error)
-    #[serde(skip_serializing_if = "Level::is_error")]
+    #[serde(default = "event::default_level", skip_serializing_if = "Level::is_error")]
     pub level: Level,
     /// An optional fingerprint configuration to override the default.
-    #[serde(skip_serializing_if = "is_default_fingerprint")]
+    #[serde(
+        default = "event::default_fingerprint",
+        skip_serializing_if = "event::is_default_fingerprint"
+    )]
     pub fingerprint: Cow<'a, [Cow<'a, str>]>,
     /// The culprit of the event.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub culprit: Option<String>,
     /// The transaction name of the event.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transaction: Option<String>,
     /// A message to be sent with the event.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     /// Optionally a log entry that can be used instead of the message for
     /// more complex cases.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub logentry: Option<LogEntry>,
     /// Optionally the name of the logger that created this event.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub logger: Option<String>,
     /// Optionally a name to version mapping of installed modules.
-    #[serde(skip_serializing_if = "Map::is_empty")]
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub modules: Map<String, String>,
     /// A platform identifier for this event.
-    #[serde(skip_serializing_if = "is_other")]
+    #[serde(
+        default = "event::default_platform", skip_serializing_if = "event::is_default_platform"
+    )]
     pub platform: Cow<'a, str>,
     /// The timestamp of when the event was created.
     ///
     /// This can be set to `None` in which case the server will set a timestamp.
-    #[serde(skip_serializing_if = "Option::is_none", with = "ts_seconds_float_opt")]
-    pub timestamp: Option<DateTime<Utc>>,
+    #[serde(default = "event::default_timestamp", with = "ts_seconds_float")]
+    pub timestamp: DateTime<Utc>,
     /// Optionally the server (or device) name of this event.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server_name: Option<Cow<'a, str>>,
     /// A release identifier.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub release: Option<Cow<'a, str>>,
     /// An optional distribution identifer.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dist: Option<Cow<'a, str>>,
     /// Repository references
-    #[serde(skip_serializing_if = "Map::is_empty")]
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub repos: Map<String, RepoReference>,
     /// An optional environment identifier.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub environment: Option<Cow<'a, str>>,
     /// Optionally user data to be sent along.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
     /// Optionally HTTP request data to be sent along.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request: Option<Request>,
     /// Optional contexts.
-    #[serde(skip_serializing_if = "Map::is_empty")]
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub contexts: Map<String, Context>,
     /// List of breadcrumbs to send along.
-    #[serde(skip_serializing_if = "Values::is_empty")]
+    #[serde(default, skip_serializing_if = "Values::is_empty")]
     pub breadcrumbs: Values<Breadcrumb>,
     /// Exceptions to be attached (one or multiple if chained).
-    #[serde(skip_serializing_if = "Values::is_empty", rename = "exception")]
-    pub exceptions: Values<Exception>,
+    #[serde(default, skip_serializing_if = "Values::is_empty")]
+    pub exception: Values<Exception>,
     /// A single stacktrace (deprecated)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stacktrace: Option<Stacktrace>,
     /// Simplified template error location info
-    #[serde(skip_serializing_if = "Option::is_none", rename = "template")]
-    pub template_info: Option<TemplateInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub template: Option<TemplateInfo>,
     /// A list of threads.
-    #[serde(skip_serializing_if = "Values::is_empty")]
+    #[serde(default, skip_serializing_if = "Values::is_empty")]
     pub threads: Values<Thread>,
     /// Optional tags to be attached to the event.
-    #[serde(skip_serializing_if = "Map::is_empty")]
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub tags: Map<String, String>,
     /// Optional extra information to be sent with the event.
-    #[serde(skip_serializing_if = "Map::is_empty")]
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub extra: Map<String, Value>,
     /// Debug meta information.
-    #[serde(skip_serializing_if = "DebugMeta::is_empty")]
+    #[serde(default, skip_serializing_if = "DebugMeta::is_empty")]
     pub debug_meta: Cow<'a, DebugMeta>,
     /// SDK metadata
-    #[serde(rename = "sdk", skip_serializing_if = "Option::is_none")]
-    pub sdk_info: Option<Cow<'a, ClientSdkInfo>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sdk: Option<Cow<'a, ClientSdkInfo>>,
 }
 
 impl<'a> Default for Event<'a> {
-    fn default() -> Event<'a> {
+    fn default() -> Self {
         Event {
-            id: None,
-            level: Level::Error,
-            fingerprint: Cow::Borrowed(DEFAULT_FINGERPRINT),
-            culprit: None,
-            transaction: None,
-            message: None,
-            logentry: None,
-            logger: None,
-            modules: Map::new(),
-            platform: "other".into(),
-            timestamp: None,
-            server_name: None,
-            release: None,
-            dist: None,
-            repos: Map::new(),
-            environment: None,
-            user: None,
-            request: None,
-            contexts: Map::new(),
-            breadcrumbs: Values::new(),
-            exceptions: Values::new(),
-            stacktrace: None,
-            template_info: None,
-            threads: Values::new(),
-            tags: Map::new(),
-            extra: Map::new(),
+            event_id: event::default_id(),
+            level: event::default_level(),
+            fingerprint: event::default_fingerprint(),
+            culprit: Default::default(),
+            transaction: Default::default(),
+            message: Default::default(),
+            logentry: Default::default(),
+            logger: Default::default(),
+            modules: Default::default(),
+            platform: event::default_platform(),
+            timestamp: event::default_timestamp(),
+            server_name: Default::default(),
+            release: Default::default(),
+            dist: Default::default(),
+            repos: Default::default(),
+            environment: Default::default(),
+            user: Default::default(),
+            request: Default::default(),
+            contexts: Default::default(),
+            breadcrumbs: Default::default(),
+            exception: Default::default(),
+            stacktrace: Default::default(),
+            template: Default::default(),
+            threads: Default::default(),
+            tags: Default::default(),
+            extra: Default::default(),
             debug_meta: Default::default(),
-            sdk_info: None,
+            sdk: Default::default(),
         }
     }
 }
@@ -1359,16 +1378,13 @@ impl<'a> Default for Event<'a> {
 impl<'a> Event<'a> {
     /// Creates a new event with the current timestamp and random id.
     pub fn new() -> Event<'a> {
-        let mut rv: Event = Default::default();
-        rv.timestamp = Some(Utc::now());
-        rv.id = Some(Uuid::new_v4());
-        rv
+        Default::default()
     }
 
     /// Creates a fully owned version of the event.
     pub fn into_owned(self) -> Event<'static> {
         Event {
-            id: self.id,
+            event_id: self.event_id,
             level: self.level,
             fingerprint: Cow::Owned(
                 self.fingerprint
@@ -1393,27 +1409,20 @@ impl<'a> Event<'a> {
             request: self.request,
             contexts: self.contexts,
             breadcrumbs: self.breadcrumbs,
-            exceptions: self.exceptions,
+            exception: self.exception,
             stacktrace: self.stacktrace,
-            template_info: self.template_info,
+            template: self.template,
             threads: self.threads,
             tags: self.tags,
             extra: self.extra,
             debug_meta: Cow::Owned(self.debug_meta.into_owned()),
-            sdk_info: self.sdk_info.map(|x| Cow::Owned(x.into_owned())),
+            sdk: self.sdk.map(|x| Cow::Owned(x.into_owned())),
         }
     }
 }
 
 impl<'a> fmt::Display for Event<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.id {
-            Some(ref id) => write!(f, "Event(id: {}", id)?,
-            None => write!(f, "Event(id: missing")?,
-        }
-        if let Some(ref ts) = self.timestamp {
-            write!(f, ", ts: {}", ts)?;
-        }
-        write!(f, ")")
+        write!(f, "Event(id: {}, ts: {})", self.event_id, self.timestamp)
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -82,32 +82,3 @@ pub mod ts_seconds_float {
         }
     }
 }
-
-#[cfg(feature = "with_serde")]
-pub mod ts_seconds_float_opt {
-    use chrono::{DateTime, Utc};
-    use serde::Deserialize;
-    use serde::{de, ser};
-
-    use super::ts_seconds_float;
-
-    #[derive(Debug, Serialize, Deserialize)]
-    struct WrappedTimestamp(#[serde(with = "ts_seconds_float")] DateTime<Utc>);
-
-    pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        Option::<WrappedTimestamp>::deserialize(d).map(|opt| opt.map(|wrapped| wrapped.0))
-    }
-
-    pub fn serialize<S>(opt_dt: &Option<DateTime<Utc>>, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        match *opt_dt {
-            Some(ref dt) => s.serialize_some(&WrappedTimestamp(*dt)),
-            None => s.serialize_none(),
-        }
-    }
-}

--- a/tests/test_protocol_v7.rs
+++ b/tests/test_protocol_v7.rs
@@ -6,10 +6,19 @@ extern crate sentry_types;
 extern crate serde;
 extern crate uuid;
 
-use chrono::Utc;
+use chrono::{DateTime, TimeZone, Utc};
 use std::borrow::Cow;
+use uuid::Uuid;
 
 use sentry_types::protocol::v7;
+
+fn event_id() -> Uuid {
+    "d43e86c9-6e42-4a93-a4fb-da156dd17341".parse().unwrap()
+}
+
+fn event_time() -> DateTime<Utc> {
+    Utc.ymd(2017, 12, 24).and_hms(8, 12, 0)
+}
 
 fn reserialize(event: &v7::Event) -> v7::Event<'static> {
     let json = serde_json::to_string(event).unwrap();
@@ -23,7 +32,6 @@ fn assert_roundtrip(event: &v7::Event) {
 
 mod test_event {
     use super::*;
-    use chrono::TimeZone;
 
     #[test]
     fn test_event_default_vs_new() {
@@ -37,22 +45,10 @@ mod test_event {
     }
 
     #[test]
-    fn test_event_to_string() {
-        let event = v7::Event {
-            event_id: "d43e86c9-6e42-4a93-a4fb-da156dd17341".parse().unwrap(),
-            ..Default::default()
-        };
-        assert_eq!(
-            event.to_string(),
-            "Event(id: d43e86c9-6e42-4a93-a4fb-da156dd17341)"
-        );
-    }
-
-    #[test]
     fn test_event_to_string_timestamp() {
         let event = v7::Event {
-            event_id: "d43e86c9-6e42-4a93-a4fb-da156dd17341".parse().unwrap(),
-            timestamp: Utc.ymd(2017, 12, 24).and_hms(8, 12, 0),
+            event_id: event_id(),
+            timestamp: event_time(),
             ..Default::default()
         };
         assert_eq!(
@@ -64,6 +60,8 @@ mod test_event {
     #[test]
     fn test_event_release_and_dist() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             dist: Some("42".into()),
             release: Some("my.awesome.app-1.0".into()),
             environment: Some("prod".into()),
@@ -72,13 +70,16 @@ mod test_event {
 
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"release\":\"my.awesome.app-1.0\",\"dist\":\"42\",\"environment\":\"prod\"}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"release\":\"my.awesome.app-1.0\",\"dist\":\"42\",\"environment\":\"prod\"}"
         );
     }
 
     #[test]
     fn test_transaction() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             message: Some("Hello World!".to_string()),
             transaction: Some("bar::foo".to_string()),
             level: v7::Level::Info,
@@ -87,27 +88,34 @@ mod test_event {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"level\":\"info\",\"transaction\":\"bar::foo\",\"message\":\"Hello World!\"}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"level\":\"info\",\
+             \"transaction\":\"bar::foo\",\"message\":\"Hello World!\",\"timestamp\":1514103120}"
         );
     }
 
     #[test]
     fn test_logger() {
-        let mut event: v7::Event = Default::default();
-        event.level = v7::Level::Warning;
-        event.message = Some("Hello World!".into());
-        event.logger = Some("root".into());
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            level: v7::Level::Warning,
+            message: Some("Hello World!".to_string()),
+            logger: Some("root".to_string()),
+            ..Default::default()
+        };
         assert_roundtrip(&event);
-        let json = serde_json::to_string(&event).unwrap();
         assert_eq!(
-            &json,
-            "{\"level\":\"warning\",\"message\":\"Hello World!\",\"logger\":\"root\"}"
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"level\":\"warning\",\"message\":\
+             \"Hello World!\",\"logger\":\"root\",\"timestamp\":1514103120}"
         );
     }
 
     #[test]
     fn test_culprit() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             message: Some("Hello World!".to_string()),
             culprit: Some("foo in bar".to_string()),
             level: v7::Level::Info,
@@ -116,7 +124,8 @@ mod test_event {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"level\":\"info\",\"culprit\":\"foo in bar\",\"message\":\"Hello World!\"}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"level\":\"info\",\"culprit\":\
+             \"foo in bar\",\"message\":\"Hello World!\",\"timestamp\":1514103120}"
         );
     }
 }
@@ -126,18 +135,18 @@ mod test_fingerprint {
 
     #[test]
     fn test_fingerprint_simple() {
-        let mut event: v7::Event = Default::default();
-        assert_eq!(serde_json::to_string(&event).unwrap(), "{}");
-
-        event.fingerprint = {
-            let mut fp = event.fingerprint.into_owned();
-            fp.push("extra".into());
-            Cow::Owned(fp)
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            fingerprint: Cow::Owned(vec!["{{ default }}".into(), "extra".into()]),
+            ..Default::default()
         };
+
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"fingerprint\":[\"{{ default }}\",\"extra\"]}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"fingerprint\":[\"{{ default \
+             }}\",\"extra\"],\"timestamp\":1514103120}"
         );
     }
 
@@ -145,10 +154,15 @@ mod test_fingerprint {
     fn test_fingerprint_string() {
         assert_eq!(
             v7::Event {
+                event_id: event_id(),
+                timestamp: event_time(),
                 fingerprint: Cow::Borrowed(&["fingerprint".into()]),
                 ..Default::default()
             },
-            serde_json::from_str("{\"fingerprint\":[\"fingerprint\"]}").unwrap()
+            serde_json::from_str(
+                "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"fingerprint\":\
+                 [\"fingerprint\"],\"timestamp\":1514103120}"
+            ).unwrap()
         )
     }
 
@@ -156,10 +170,15 @@ mod test_fingerprint {
     fn test_fingerprint_empty() {
         assert_eq!(
             v7::Event {
+                event_id: event_id(),
+                timestamp: event_time(),
                 fingerprint: Cow::Borrowed(&[]),
                 ..Default::default()
             },
-            serde_json::from_str("{\"fingerprint\":[]}").unwrap()
+            serde_json::from_str(
+                "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"fingerprint\":[],\
+                 \"timestamp\":1514103120}"
+            ).unwrap()
         )
     }
 }
@@ -205,6 +224,8 @@ mod test_logentry {
     #[test]
     fn test_logentry_basics() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             logentry: Some(v7::LogEntry {
                 message: "Hello %s!".to_string(),
                 params: vec!["World".into()],
@@ -216,14 +237,17 @@ mod test_logentry {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"level\":\"debug\",\"culprit\":\"foo in bar\",\"logentry\":{\"message\":\
-             \"Hello %s!\",\"params\":[\"World\"]}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"level\":\"debug\",\"culprit\":\
+             \"foo in bar\",\"logentry\":{\"message\":\"Hello \
+             %s!\",\"params\":[\"World\"]},\"timestamp\":1514103120}"
         );
     }
 
     #[test]
     fn test_logentry_no_params() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             logentry: Some(v7::LogEntry {
                 message: "Hello World!".to_string(),
                 params: vec![],
@@ -233,7 +257,8 @@ mod test_logentry {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"logentry\":{\"message\":\"Hello World!\"}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"logentry\":{\"message\":\"Hello \
+             World!\"},\"timestamp\":1514103120}"
         );
     }
 }
@@ -241,6 +266,8 @@ mod test_logentry {
 #[test]
 fn test_modules() {
     let event = v7::Event {
+        event_id: event_id(),
+        timestamp: event_time(),
         modules: {
             let mut m = v7::Map::new();
             m.insert("System".into(), "1.0.0".into());
@@ -251,7 +278,8 @@ fn test_modules() {
     assert_roundtrip(&event);
     assert_eq!(
         serde_json::to_string(&event).unwrap(),
-        "{\"modules\":{\"System\":\"1.0.0\"}}"
+        "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"modules\":{\"System\":\"1.0.0\"},\
+         \"timestamp\":1514103120}"
     );
 }
 
@@ -261,6 +289,8 @@ mod test_repos {
     #[test]
     fn test_repos() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             repos: {
                 let mut m = v7::Map::new();
                 m.insert(
@@ -279,13 +309,16 @@ mod test_repos {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"repos\":{\"/raven\":{\"name\":\"github/raven\"}}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"repos\":{\"/raven\":{\"name\":\"github/raven\"}}}"
         );
     }
 
     #[test]
     fn test_repos_with_revision() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             repos: {
                 let mut m = v7::Map::new();
                 m.insert(
@@ -304,8 +337,9 @@ mod test_repos {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"repos\":{\"/raven\":{\"name\":\"github/raven\",\
-             \"prefix\":\"/\",\"revision\":\"49f45700b5fe606c1bcd9bf0205ecbb83db17f52\"}}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"repos\":{\"/raven\":{\"name\":\"github/raven\",\"prefix\":\"/\",\"revision\":\
+             \"49f45700b5fe606c1bcd9bf0205ecbb83db17f52\"}}}"
         );
     }
 }
@@ -317,24 +351,26 @@ mod test_timestamp {
     #[test]
     fn test_timestamp_utc() {
         let event = v7::Event {
-            timestamp: Utc.ymd(2017, 12, 24).and_hms(8, 12, 0),
+            event_id: event_id(),
+            timestamp: event_time(),
             ..Default::default()
         };
 
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"timestamp\":1514103120}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120}"
         );
 
         let event: v7::Event =
-            serde_json::from_slice(b"{\"timestamp\":\"2014-05-06T07:08:09Z\"}").unwrap();
-        assert_eq!(event.timestamp, Utc.ymd(2014, 5, 6).and_hms(7, 8, 9));
+            serde_json::from_slice(b"{\"timestamp\":\"2017-12-24T08:12:00Z\"}").unwrap();
+        assert_eq!(event.timestamp, event_time());
     }
 
     #[test]
     fn test_timestamp_float() {
         let event = v7::Event {
+            event_id: event_id(),
             timestamp: Utc.ymd(2017, 12, 24).and_hms_milli(8, 12, 0, 500),
             ..Default::default()
         };
@@ -342,7 +378,7 @@ mod test_timestamp {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"timestamp\":1514103120.5}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120.5}"
         );
     }
 }
@@ -353,6 +389,8 @@ mod test_user {
     #[test]
     fn test_user_minimal() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             user: Some(v7::User {
                 id: Some("8fd5a33b-5b0e-45b2-aff2-9e4f067756ba".into()),
                 ..Default::default()
@@ -363,13 +401,16 @@ mod test_user {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"user\":{\"id\":\"8fd5a33b-5b0e-45b2-aff2-9e4f067756ba\"}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"user\":\
+             {\"id\":\"8fd5a33b-5b0e-45b2-aff2-9e4f067756ba\"}}"
         );
     }
 
     #[test]
     fn test_user_full() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             user: Some(v7::User {
                 id: Some("8fd5a33b-5b0e-45b2-aff2-9e4f067756ba".into()),
                 email: Some("foo@example.invalid".into()),
@@ -382,15 +423,17 @@ mod test_user {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"user\":{\"id\":\"8fd5a33b-5b0e-45b2-aff2-9e4f067756ba\",\
-             \"email\":\"foo@example.invalid\",\"ip_address\":\"127.0.0.1\",\
-             \"username\":\"john-doe\"}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"user\":\
+             {\"id\":\"8fd5a33b-5b0e-45b2-aff2-9e4f067756ba\",\"email\":\"foo@example.invalid\",\
+             \"ip_address\":\"127.0.0.1\",\"username\":\"john-doe\"}}"
         );
     }
 
     #[test]
     fn test_user_ip_address_auto() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             user: Some(v7::User {
                 ip_address: Some(v7::IpAddress::Auto),
                 ..Default::default()
@@ -401,26 +444,29 @@ mod test_user {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"user\":{\"ip_address\":\"{{auto}}\"}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"user\":\
+             {\"ip_address\":\"{{auto}}\"}}"
         );
     }
 }
 
 mod test_breadcrumbs {
     use super::*;
-    use chrono::TimeZone;
 
-    fn event() -> v7::Event<'static> {
-        v7::Event {
+    #[test]
+    fn test_breadcrumbs_values() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             breadcrumbs: vec![
                 v7::Breadcrumb {
-                    timestamp: Utc.ymd(2017, 12, 24).and_hms_milli(8, 12, 0, 713),
+                    timestamp: event_time(),
                     category: Some("ui.click".into()),
                     message: Some("span.platform-card > li.platform-tile".into()),
                     ..Default::default()
                 },
                 v7::Breadcrumb {
-                    timestamp: Utc.ymd(2017, 12, 24).and_hms_milli(8, 12, 0, 913),
+                    timestamp: event_time(),
                     ty: "http".into(),
                     category: Some("xhr".into()),
                     data: {
@@ -434,19 +480,16 @@ mod test_breadcrumbs {
                 },
             ].into(),
             ..Default::default()
-        }
-    }
-
-    #[test]
-    fn test_breadcrumbs_values() {
-        let event = event();
+        };
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"breadcrumbs\":{\"values\":[{\"timestamp\":1514103120.713,\"type\":\"default\",\
-             \"category\":\"ui.click\",\"message\":\"span.platform-card > li.platform-tile\"\
-             },{\"timestamp\":1514103120.913,\"type\":\"http\",\"category\":\"xhr\",\"data\"\
-             :{\"method\":\"GET\",\"status_code\":200,\"url\":\"/api/0/organizations/foo\"}}]}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"breadcrumbs\":{\"values\":[{\"timestamp\":1514103120,\"category\":\"ui.click\",\
+             \"message\":\"span.platform-card > \
+             li.platform-tile\"},{\"timestamp\":1514103120,\"type\":\"http\",\"category\":\"xhr\",\
+             \"data\":{\"method\":\"GET\",\"status_code\":200,\"url\":\
+             \"/api/0/organizations/foo\"}}]}}"
         );
     }
 }
@@ -457,6 +500,8 @@ mod test_stacktrace {
     #[test]
     fn test_stacktrace() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             stacktrace: Some(v7::Stacktrace {
                 frames: vec![v7::Frame {
                     function: Some("main".into()),
@@ -472,8 +517,9 @@ mod test_stacktrace {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"stacktrace\":{\"frames\":[{\"function\":\"main\",\
-             \"filename\":\"hello.py\",\"lineno\":1}]}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"stacktrace\":{\"frames\":[{\"function\":\"main\",\"filename\":\"hello.py\",\
+             \"lineno\":1}]}}"
         );
     }
 }
@@ -484,6 +530,8 @@ mod test_template_info {
     #[test]
     fn test_template_info() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             template: Some(v7::TemplateInfo {
                 filename: Some("hello.html".into()),
                 lineno: Some(1),
@@ -498,9 +546,9 @@ mod test_template_info {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"template\":{\"filename\":\"hello.html\",\"lineno\":1,\
-             \"pre_context\":[\"foo1\",\"bar2\"],\"context_line\":\
-             \"hey hey hey3\",\"post_context\":[\"foo4\",\"bar5\"]}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"template\":{\"filename\":\"hello.html\",\"lineno\":1,\"pre_context\":[\"foo1\",\
+             \"bar2\"],\"context_line\":\"hey hey hey3\",\"post_context\":[\"foo4\",\"bar5\"]}}"
         );
     }
 }
@@ -511,6 +559,8 @@ mod test_threads {
     #[test]
     fn test_threads_values() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             threads: vec![v7::Thread {
                 id: Some("#1".into()),
                 name: Some("Awesome Thread".into()),
@@ -522,13 +572,16 @@ mod test_threads {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"threads\":{\"values\":[{\"id\":\"#1\",\"name\":\"Awesome Thread\"}]}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"threads\":{\"values\":[{\"id\":\"#1\",\"name\":\"Awesome Thread\"}]}}"
         );
     }
 
     #[test]
     fn test_threads_flags() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             threads: vec![v7::Thread {
                 id: Some(42.into()),
                 name: Some("Awesome Thread".into()),
@@ -542,14 +595,17 @@ mod test_threads {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"threads\":{\"values\":[{\"id\":42,\"name\":\"Awesome Thread\",\
-             \"crashed\":true,\"current\":true}]}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"threads\":{\"values\":[{\"id\":42,\"name\":\"Awesome \
+             Thread\",\"crashed\":true,\"current\":true}]}}"
         );
     }
 
     #[test]
     fn test_threads_stacktrace() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             threads: vec![v7::Thread {
                 stacktrace: Some(v7::Stacktrace {
                     frames: vec![v7::Frame {
@@ -577,9 +633,10 @@ mod test_threads {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"threads\":{\"values\":[{\"stacktrace\":{\"frames\":[{\"function\":\
-             \"main\",\"filename\":\"hello.py\",\"lineno\":1}]},\"raw_stacktrace\"\
-             :{\"frames\":[{\"function\":\"main\",\"filename\":\"hello.py\",\"lineno\":1}]}}]}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"threads\":{\"values\":[{\"stacktrace\":{\"frames\":[{\"function\":\"main\",\
+             \"filename\":\"hello.py\",\"lineno\":1}]},\"raw_stacktrace\":{\"frames\":\
+             [{\"function\":\"main\",\"filename\":\"hello.py\",\"lineno\":1}]}}]}}"
         );
     }
 }
@@ -590,6 +647,8 @@ mod test_request {
     #[test]
     fn test_request_full() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             request: Some(v7::Request {
                 url: "https://www.example.invalid/bar".parse().ok(),
                 method: Some("GET".into()),
@@ -613,17 +672,18 @@ mod test_request {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"request\":{\"url\":\"https://www.example.invalid/bar\",\
-             \"method\":\"GET\",\"data\":\"{}\",\"query_string\":\
-             \"foo=bar&blub=blah\",\"cookies\":\"dummy=42\",\"headers\":\
-             {\"Content-Type\":\"text/plain\"},\"env\":\
-             {\"PATH_INFO\":\"/bar\"}}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"request\":{\"url\":\"https://www.example.invalid/bar\",\"method\":\"GET\",\"data\":\
+             \"{}\",\"query_string\":\"foo=bar&blub=blah\",\"cookies\":\"dummy=42\",\"headers\":\
+             {\"Content-Type\":\"text/plain\"},\"env\":{\"PATH_INFO\":\"/bar\"}}}"
         );
     }
 
     #[test]
     fn test_request_other() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             request: Some(v7::Request {
                 url: "https://www.example.invalid/bar".parse().ok(),
                 method: Some("GET".into()),
@@ -638,27 +698,35 @@ mod test_request {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"request\":{\"url\":\"https://www.example.invalid/bar\",\
-             \"method\":\"GET\",\"data\":\"{}\",\"query_string\":\
-             \"foo=bar&blub=blah\",\"cookies\":\"dummy=42\"}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"request\":{\"url\":\"https://www.example.invalid/bar\",\"method\":\"GET\",\"data\":\
+             \"{}\",\"query_string\":\"foo=bar&blub=blah\",\"cookies\":\"dummy=42\"}}"
         );
     }
 
     #[test]
     fn test_request_defaults() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             request: Some(Default::default()),
             ..Default::default()
         };
 
         assert_roundtrip(&event);
-        assert_eq!(serde_json::to_string(&event).unwrap(), "{\"request\":{}}");
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"request\":{}}"
+        );
     }
 }
 
 #[test]
 fn test_tags() {
     let event = v7::Event {
+        event_id: event_id(),
+        timestamp: event_time(),
         tags: {
             let mut m = v7::Map::new();
             m.insert("device_type".into(), "mobile".into());
@@ -671,13 +739,16 @@ fn test_tags() {
     assert_roundtrip(&event);
     assert_eq!(
         serde_json::to_string(&event).unwrap(),
-        "{\"tags\":{\"device_type\":\"mobile\",\"interpreter\":\"7\"}}"
+        "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"tags\":\
+         {\"device_type\":\"mobile\",\"interpreter\":\"7\"}}"
     );
 }
 
 #[test]
 fn test_extra() {
     let event = v7::Event {
+        event_id: event_id(),
+        timestamp: event_time(),
         extra: {
             let mut m = v7::Map::new();
             m.insert(
@@ -695,7 +766,8 @@ fn test_extra() {
     assert_roundtrip(&event);
     assert_eq!(
         serde_json::to_string(&event).unwrap(),
-        "{\"extra\":{\"component_state\":{\"dirty\":true,\"revision\":17}}}"
+        "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"extra\":\
+         {\"component_state\":{\"dirty\":true,\"revision\":17}}}"
     );
 }
 
@@ -705,6 +777,8 @@ mod test_debug_meta {
     #[test]
     fn test_debug_meta() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             debug_meta: Cow::Owned(v7::DebugMeta {
                 sdk_info: Some(v7::SystemSdkInfo {
                     sdk_name: "iOS".into(),
@@ -720,7 +794,8 @@ mod test_debug_meta {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"debug_meta\":{\"sdk_info\":{\"sdk_name\":\"iOS\",\"version_major\":10,\
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"debug_meta\":{\"sdk_info\":{\"sdk_name\":\"iOS\",\"version_major\":10,\
              \"version_minor\":3,\"version_patchlevel\":0}}}"
         );
     }
@@ -728,6 +803,8 @@ mod test_debug_meta {
     #[test]
     fn test_debug_meta_images() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             debug_meta: Cow::Owned(v7::DebugMeta {
                 images: vec![
                     v7::AppleDebugImage {
@@ -760,14 +837,14 @@ mod test_debug_meta {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"debug_meta\":{\"images\":[{\"type\":\"apple\",\"name\":\"CoreFoundation\",\"arch\":\
-             \"arm64\",\"cpu_type\":1233,\"cpu_subtype\":3,\"image_addr\":\"0x0\",\
-             \"image_size\":4096,\"image_vmaddr\":\"0x8000\",\"uuid\":\
-             \"494f3aea-88fa-4296-9644-fa8ef5d139b6\"},\
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"debug_meta\":{\"images\":[{\"type\":\"apple\",\"name\":\"CoreFoundation\",\"arch\":\
+             \"arm64\",\"cpu_type\":1233,\"cpu_subtype\":3,\"image_addr\":\"0x0\",\"image_size\":\
+             4096,\"image_vmaddr\":\"0x8000\",\"uuid\":\"494f3aea-88fa-4296-9644-fa8ef5d139b6\"},\
              {\"type\":\"symbolic\",\"name\":\"CoreFoundation\",\"arch\":\"arm64\",\"image_addr\":\
              \"0x0\",\"image_size\":4096,\"image_vmaddr\":\"0x8000\",\"id\":\
-             \"494f3aea-88fa-4296-9644-fa8ef5d139b6-1234\"},\
-             {\"type\":\"proguard\",\"uuid\":\"8c954262-f905-4992-8a61-f60825f4553b\"}]}}"
+             \"494f3aea-88fa-4296-9644-fa8ef5d139b6-1234\"},{\"type\":\"proguard\",\"uuid\":\
+             \"8c954262-f905-4992-8a61-f60825f4553b\"}]}}"
         );
     }
 }
@@ -777,25 +854,28 @@ mod test_exception {
 
     #[test]
     fn test_exception_values() {
-        let mut event: v7::Event = Default::default();
-        event.exception.values.push(v7::Exception {
-            ty: "ZeroDivisionError".into(),
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            exception: vec![v7::Exception {
+                ty: "ZeroDivisionError".into(),
+                ..Default::default()
+            }].into(),
             ..Default::default()
-        });
-        let json = serde_json::to_string(&event).unwrap();
+        };
         assert_roundtrip(&event);
         assert_eq!(
-            json,
-            "{\"exception\":{\"values\":[{\"type\":\"ZeroDivisionError\"}]}}"
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"exception\":{\"values\":[{\"type\":\"ZeroDivisionError\"}]}}"
         );
-
-        let event2: v7::Event = serde_json::from_str(&json).unwrap();
-        assert_eq!(event, event2);
     }
 
     #[test]
     fn test_exception_stacktrace_minimal() {
         let event: v7::Event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             exception: vec![v7::Exception {
                 ty: "DivisionByZero".into(),
                 value: Some("integer division or modulo by zero".into()),
@@ -818,9 +898,10 @@ mod test_exception {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"exception\":{\"values\":[{\"type\":\"DivisionByZero\",\
-             \"value\":\"integer division or modulo by zero\",\"stacktrace\":\
-             {\"frames\":[{\"function\":\"main\",\"filename\":\"hello.py\",\
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"exception\":{\"values\":[{\"type\":\"DivisionByZero\",\"value\":\"integer division \
+             or modulo by \
+             zero\",\"stacktrace\":{\"frames\":[{\"function\":\"main\",\"filename\":\"hello.py\",\
              \"lineno\":1}]}}]}}"
         );
     }
@@ -828,6 +909,8 @@ mod test_exception {
     #[test]
     fn test_exception_stacktrace_larger() {
         let event: v7::Event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             exception: vec![v7::Exception {
                 ty: "DivisionByZero".into(),
                 value: Some("integer division or modulo by zero".into()),
@@ -860,18 +943,21 @@ mod test_exception {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"exception\":{\"values\":[{\"type\":\"DivisionByZero\",\"value\":\
-             \"integer division or modulo by zero\",\"stacktrace\":{\"frames\":\
-             [{\"function\":\"main\",\"filename\":\"hello.py\",\"lineno\":7,\
-             \"colno\":42,\"pre_context\":[\"foo\",\"bar\"],\"context_line\":\
-             \"hey hey hey\",\"post_context\":[\"foo\",\"bar\"],\"in_app\":true,\
-             \"vars\":{\"var\":\"value\"}}]}}]}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"exception\":{\"values\":[{\"type\":\"DivisionByZero\",\"value\":\"integer division \
+             or modulo by \
+             zero\",\"stacktrace\":{\"frames\":[{\"function\":\"main\",\"filename\":\"hello.py\",\
+             \"lineno\":7,\"colno\":42,\"pre_context\":[\"foo\",\"bar\"],\"context_line\":\"hey \
+             hey hey\",\"post_context\":[\"foo\",\"bar\"],\"in_app\":true,\"vars\":{\"var\":\
+             \"value\"}}]}}]}}"
         );
     }
 
     #[test]
     fn test_exception_stacktrace_full() {
         let event: v7::Event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             exception: vec![v7::Exception {
                 ty: "DivisionByZero".into(),
                 value: Some("integer division or modulo by zero".into()),
@@ -959,32 +1045,35 @@ mod test_exception {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"exception\":{\"values\":[{\"type\":\"DivisionByZero\",\"value\":\
-             \"integer division or modulo by zero\",\"module\":\"x\",\"stacktrace\":\
-             {\"frames\":[{\"function\":\"main\",\"symbol\":\"main\",\"module\":\
-             \"hello\",\"package\":\"hello.whl\",\"filename\":\"hello.py\",\"abs_path\"\
-             :\"/app/hello.py\",\"lineno\":7,\"colno\":42,\"pre_context\":[\"foo\",\"\
-             bar\"],\"context_line\":\"hey hey hey\",\"post_context\":[\"foo\",\"bar\"]\
-             ,\"in_app\":true,\"vars\":{\"var\":\"value\"},\"image_addr\":\"0x0\",\
-             \"instruction_addr\":\"0x0\",\"symbol_addr\":\"0x0\"}],\"frames_omitted\":\
-             [1,2],\"registers\":{\"cpsr\":\"0x20000000\",\"fp\":\"0x16fd75060\",\"lr\":\
-             \"0x18a31aadc\",\"pc\":\"0x18a310ea4\",\"sp\":\"0x16fd75060\",\"x0\":\"0x1\",\
-             \"x1\":\"0x1b1399bb1\",\"x10\":\"0x57b\",\"x11\":\"0x1b3b37b1d\",\"x12\":\
-             \"0x1b3b37b1d\",\"x13\":\"0x1\",\"x14\":\"0x1\",\"x15\":\"0x881\",\"x16\":\
-             \"0x18a31aa34\",\"x17\":\"0x0\",\"x18\":\"0x0\",\"x19\":\"0x0\",\"x2\":\"0x1\"\
-             ,\"x20\":\"0x1\",\"x21\":\"0x1\",\"x22\":\"0x1b1399bb0\",\"x23\":\"0x1afe10040\"\
-             ,\"x24\":\"0x1b1399c20\",\"x25\":\"0x0\",\"x26\":\"0x191ec48d1\",\"x27\":\"0x1\",\
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"exception\":{\"values\":[{\"type\":\"DivisionByZero\",\"value\":\"integer division \
+             or modulo by \
+             zero\",\"module\":\"x\",\"stacktrace\":{\"frames\":[{\"function\":\"main\",\
+             \"symbol\":\"main\",\"module\":\"hello\",\"package\":\"hello.whl\",\"filename\":\
+             \"hello.py\",\"abs_path\":\"/app/hello.py\",\"lineno\":7,\"colno\":42,\
+             \"pre_context\":[\"foo\",\"bar\"],\"context_line\":\"hey hey \
+             hey\",\"post_context\":[\"foo\",\"bar\"],\"in_app\":true,\"vars\":{\"var\":\
+             \"value\"},\"image_addr\":\"0x0\",\"instruction_addr\":\"0x0\",\"symbol_addr\":\
+             \"0x0\"}],\"frames_omitted\":[1,2],\"registers\":{\"cpsr\":\"0x20000000\",\"fp\":\
+             \"0x16fd75060\",\"lr\":\"0x18a31aadc\",\"pc\":\"0x18a310ea4\",\"sp\":\"0x16fd75060\",\
+             \"x0\":\"0x1\",\"x1\":\"0x1b1399bb1\",\"x10\":\"0x57b\",\"x11\":\"0x1b3b37b1d\",\
+             \"x12\":\"0x1b3b37b1d\",\"x13\":\"0x1\",\"x14\":\"0x1\",\"x15\":\"0x881\",\"x16\":\
+             \"0x18a31aa34\",\"x17\":\"0x0\",\"x18\":\"0x0\",\"x19\":\"0x0\",\"x2\":\"0x1\",\
+             \"x20\":\"0x1\",\"x21\":\"0x1\",\"x22\":\"0x1b1399bb0\",\"x23\":\"0x1afe10040\",\
+             \"x24\":\"0x1b1399c20\",\"x25\":\"0x0\",\"x26\":\"0x191ec48d1\",\"x27\":\"0x1\",\
              \"x28\":\"0x17025f650\",\"x29\":\"0x16fd75060\",\"x3\":\"0x1\",\"x4\":\
-             \"0x1702eb100\",\"x5\":\"0x1702eb100\",\"x6\":\"0x0\",\"x7\":\"0x0\",\"x8\":\
-             \"0x0\",\"x9\":\"0x1b1399c20\"}},\"raw_stacktrace\":{\"frames\":[{\"function\":\
-             \"main\",\"image_addr\":\"0x0\",\"instruction_addr\":\"0x0\",\"symbol_addr\":\
-             \"0x0\"}],\"frames_omitted\":[1,2]}}]}}"
+             \"0x1702eb100\",\"x5\":\"0x1702eb100\",\"x6\":\"0x0\",\"x7\":\"0x0\",\"x8\":\"0x0\",\
+             \"x9\":\"0x1b1399c20\"}},\"raw_stacktrace\":{\"frames\":[{\"function\":\"main\",\
+             \"image_addr\":\"0x0\",\"instruction_addr\":\"0x0\",\"symbol_addr\":\"0x0\"}],\
+             \"frames_omitted\":[1,2]}}]}}"
         );
     }
 
     #[test]
     fn test_exception_mechanism() {
         let event: v7::Event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             exception: vec![v7::Exception {
                 ty: "EXC_BAD_ACCESS".into(),
                 value: Some("Attempted to dereference garbage pointer 0x1".into()),
@@ -1029,11 +1118,13 @@ mod test_exception {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"exception\":{\"values\":[{\"type\":\"EXC_BAD_ACCESS\",\"value\":\"Attempted to \
-            dereference garbage pointer 0x1\",\"mechanism\":{\"type\":\"mach\",\"help_link\":\"\
-            https://developer.apple.com/library/content/qa/qa1367/_index.html\",\"handled\":false,\"\
-            data\":{\"relevant_address\":\"0x1\"},\"meta\":{\"errno\":{\"number\":2},\"signal\":{\"\
-            number\":11},\"mach_exception\":{\"exception\":1,\"code\":1,\"subcode\":8}}}}]}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"exception\":{\"values\":[{\"type\":\"EXC_BAD_ACCESS\",\"value\":\"Attempted to \
+             dereference garbage pointer \
+             0x1\",\"mechanism\":{\"type\":\"mach\",\"help_link\":\"https://developer.apple.\
+             com/library/content/qa/qa1367/_index.html\",\"handled\":false,\"data\":\
+             {\"relevant_address\":\"0x1\"},\"meta\":{\"errno\":{\"number\":2},\"signal\":\
+             {\"number\":11},\"mach_exception\":{\"exception\":1,\"code\":1,\"subcode\":8}}}}]}}"
         );
     }
 }
@@ -1041,6 +1132,8 @@ mod test_exception {
 #[test]
 fn test_sdk_info() {
     let event = v7::Event {
+        event_id: event_id(),
+        timestamp: event_time(),
         sdk: Some(Cow::Owned(v7::ClientSdkInfo {
             name: "sentry-rust".into(),
             version: "1.0".into(),
@@ -1056,9 +1149,9 @@ fn test_sdk_info() {
     assert_roundtrip(&event);
     assert_eq!(
         serde_json::to_string(&event).unwrap(),
-        "{\"sdk\":{\"name\":\"sentry-rust\",\"version\":\"1.0\",\
-         \"integrations\":[\"rocket\"],\
-         \"packages\":[{\"package_name\":\"crates:sentry\",\"version\":\"1.0\"}]}}"
+        "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"sdk\":\
+         {\"name\":\"sentry-rust\",\"version\":\"1.0\",\"integrations\":[\"rocket\"],\"packages\":\
+         [{\"package_name\":\"crates:sentry\",\"version\":\"1.0\"}]}}"
     );
 }
 
@@ -1068,6 +1161,8 @@ mod test_contexts {
     #[test]
     fn test_device_context() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             contexts: {
                 let mut m = v7::Map::new();
                 m.insert(
@@ -1100,19 +1195,22 @@ mod test_contexts {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"device\":{\"type\":\"device\",\"name\":\"iphone\",\"family\":\"iphone\",\"model\":\
-             \"iphone7,3\",\"model_id\":\"AH223\",\"arch\":\"arm64\",\"battery_level\":58.5,\
-             \"orientation\":\"landscape\",\"simulator\":true,\"memory_size\":3137978368,\
-             \"free_memory\":322781184,\"usable_memory\":2843525120,\"storage_size\":63989469184,\
-             \"free_storage\":31994734592,\"external_storage_size\":2097152,\
-             \"external_free_storage\":2097152,\"boot_time\":\"2018-02-08T12:52:12Z\",\"timezone\":\
-             \"Europe/Vienna\"}}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"device\":{\"type\":\"device\",\"name\":\"iphone\",\"family\":\
+             \"iphone\",\"model\":\"iphone7,3\",\"model_id\":\"AH223\",\"arch\":\"arm64\",\
+             \"battery_level\":58.5,\"orientation\":\"landscape\",\"simulator\":true,\
+             \"memory_size\":3137978368,\"free_memory\":322781184,\"usable_memory\":2843525120,\
+             \"storage_size\":63989469184,\"free_storage\":31994734592,\"external_storage_size\":\
+             2097152,\"external_free_storage\":2097152,\"boot_time\":\"2018-02-08T12:52:12Z\",\
+             \"timezone\":\"Europe/Vienna\"}}}"
         );
     }
 
     #[test]
     fn test_os_context() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             contexts: {
                 let mut m = v7::Map::new();
                 m.insert(
@@ -1133,7 +1231,8 @@ mod test_contexts {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"os\":{\"type\":\"os\",\"name\":\"iOS\",\"version\":\"11.4.2\",\
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"os\":{\"type\":\"os\",\"name\":\"iOS\",\"version\":\"11.4.2\",\
              \"build\":\"ADSA23\",\"kernel_version\":\"17.4.0\",\"rooted\":true}}}"
         );
     }
@@ -1141,6 +1240,8 @@ mod test_contexts {
     #[test]
     fn test_app_context() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             contexts: {
                 let mut m = v7::Map::new();
                 m.insert(
@@ -1163,16 +1264,19 @@ mod test_contexts {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"app\":{\"type\":\"app\",\"app_start_time\":\"2018-02-08T22:21:57Z\",\
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"app\":{\"type\":\"app\",\"app_start_time\":\"2018-02-08T22:21:57Z\",\
              \"device_app_hash\":\"4c793e3776474877ae30618378e9662a\",\"build_type\":\
-             \"testflight\",\"app_identifier\":\"foo.bar.baz\",\"app_name\":\"Baz App\",\
-             \"app_version\":\"1.0\",\"app_build\":\"100001\"}}}"
+             \"testflight\",\"app_identifier\":\"foo.bar.baz\",\"app_name\":\"Baz \
+             App\",\"app_version\":\"1.0\",\"app_build\":\"100001\"}}}"
         );
     }
 
     #[test]
     fn test_browser_context() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             contexts: {
                 let mut m = v7::Map::new();
                 m.insert(
@@ -1190,14 +1294,17 @@ mod test_contexts {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"browser\":{\"type\":\"browser\",\"name\":\"Chrome\",\"version\":\
-             \"59.0.3071\"}}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"browser\":{\"type\":\"browser\",\"name\":\"Chrome\",\"version\":\"59.\
+             0.3071\"}}}"
         );
     }
 
     #[test]
     fn test_runtime_context() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             contexts: {
                 let mut m = v7::Map::new();
                 m.insert(
@@ -1215,14 +1322,17 @@ mod test_contexts {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"runtime\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\
-             \"5.3\"}}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"runtime\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\"5.\
+             3\"}}}"
         );
     }
 
     #[test]
     fn test_renamed_contexts() {
         let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
             contexts: {
                 let mut m = v7::Map::new();
                 m.insert(
@@ -1247,8 +1357,9 @@ mod test_contexts {
         assert_roundtrip(&event);
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            "{\"contexts\":{\"magicvm\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\
-             \"5.3\"},\"othervm\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\"5.3\"}}}"
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"magicvm\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\"5.\
+             3\"},\"othervm\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\"5.3\"}}}"
         );
     }
 }


### PR DESCRIPTION
This PR removes all renames and inlines flattened structs. This should align the protocol with all other SDKs. Also, the Event now has a mandatory UUID.