### PR TITLE
fix(protocol): Bring back extra fields for supported types

### DIFF
--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -82,6 +82,18 @@ impl<T> From<Vec<T>> for Values<T> {
     }
 }
 
+impl<T> AsRef<[T]> for Values<T> {
+    fn as_ref(&self) -> &[T] {
+        &self.values
+    }
+}
+
+impl<T> AsMut<Vec<T>> for Values<T> {
+    fn as_mut(&mut self) -> &mut Vec<T> {
+        &mut self.values
+    }
+}
+
 impl<T> ops::Deref for Values<T> {
     type Target = [T];
 

--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -1121,6 +1121,9 @@ pub struct DeviceContext {
     /// The timezone of the device.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
+    /// Additional arbitrary fields for forwards compatibility.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 /// Holds operating system information.
@@ -1141,6 +1144,9 @@ pub struct OsContext {
     /// An indicator if the os is rooted (mobile mostly).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rooted: Option<bool>,
+    /// Additional arbitrary fields for forwards compatibility.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 /// Holds information about the runtime.
@@ -1152,6 +1158,9 @@ pub struct RuntimeContext {
     /// The version of the runtime.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// Additional arbitrary fields for forwards compatibility.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 /// Holds app information.
@@ -1178,6 +1187,9 @@ pub struct AppContext {
     /// Internal build ID as it appears on the platform.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_build: Option<String>,
+    /// Additional arbitrary fields for forwards compatibility.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 /// Holds information about the web browser.
@@ -1189,6 +1201,9 @@ pub struct BrowserContext {
     /// The version of the browser.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// Additional arbitrary fields for forwards compatibility.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 macro_rules! into_context {

--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -834,6 +834,9 @@ pub struct User {
     /// A human readable username of the user.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
+    /// Additional arbitrary fields for forwards compatibility.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 /// Represents http request data.

--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -1042,6 +1042,9 @@ pub enum Context {
     App(Box<AppContext>),
     /// Web browser data.
     Browser(Box<BrowserContext>),
+    /// Generic other context data.
+    #[serde(rename = "unknown")]
+    Other(Map<String, Value>),
 }
 
 impl Context {
@@ -1053,6 +1056,7 @@ impl Context {
             Context::Runtime(..) => "runtime",
             Context::App(..) => "app",
             Context::Browser(..) => "browser",
+            Context::Other(..) => "unknown",
         }
     }
 }

--- a/tests/test_protocol_v7.rs
+++ b/tests/test_protocol_v7.rs
@@ -1374,6 +1374,34 @@ mod test_contexts {
              3\"},\"othervm\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\"5.3\"}}}"
         );
     }
+
+    #[test]
+    fn test_other_context() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            contexts: {
+                let mut m = v7::Map::new();
+                m.insert(
+                    "other".into(),
+                    v7::Context::Other({
+                        let mut m = v7::Map::new();
+                        m.insert("aha".into(), "oho".into());
+                        m
+                    }),
+                );
+                m
+            },
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"other\":{\"type\":\"unknown\",\"aha\":\"oho\"}}}"
+        );
+    }
 }
 
 #[test]

--- a/tests/test_protocol_v7.rs
+++ b/tests/test_protocol_v7.rs
@@ -1190,6 +1190,7 @@ mod test_contexts {
                         external_free_storage: Some(2_097_152),
                         boot_time: Some("2018-02-08T12:52:12Z".parse().unwrap()),
                         timezone: Some("Europe/Vienna".into()),
+                        other: Default::default(),
                     }.into(),
                 );
                 m
@@ -1226,6 +1227,7 @@ mod test_contexts {
                         build: Some("ADSA23".into()),
                         kernel_version: Some("17.4.0".into()),
                         rooted: Some(true),
+                        other: Default::default(),
                     }.into(),
                 );
                 m
@@ -1259,6 +1261,7 @@ mod test_contexts {
                         app_name: Some("Baz App".into()),
                         app_version: Some("1.0".into()),
                         app_build: Some("100001".into()),
+                        other: Default::default(),
                     }.into(),
                 );
                 m
@@ -1289,6 +1292,7 @@ mod test_contexts {
                     v7::BrowserContext {
                         name: Some("Chrome".into()),
                         version: Some("59.0.3071".into()),
+                        other: Default::default(),
                     }.into(),
                 );
                 m
@@ -1317,6 +1321,7 @@ mod test_contexts {
                     v7::RuntimeContext {
                         name: Some("magicvm".into()),
                         version: Some("5.3".into()),
+                        other: Default::default(),
                     }.into(),
                 );
                 m
@@ -1345,6 +1350,7 @@ mod test_contexts {
                     v7::RuntimeContext {
                         name: Some("magicvm".into()),
                         version: Some("5.3".into()),
+                        other: Default::default(),
                     }.into(),
                 );
                 m.insert(
@@ -1352,6 +1358,7 @@ mod test_contexts {
                     v7::RuntimeContext {
                         name: Some("magicvm".into()),
                         version: Some("5.3".into()),
+                        other: Default::default(),
                     }.into(),
                 );
                 m

--- a/tests/test_protocol_v7.rs
+++ b/tests/test_protocol_v7.rs
@@ -416,6 +416,11 @@ mod test_user {
                 email: Some("foo@example.invalid".into()),
                 ip_address: Some("127.0.0.1".parse().unwrap()),
                 username: Some("john-doe".into()),
+                other: {
+                    let mut hm = v7::Map::new();
+                    hm.insert("foo".into(), "bar".into());
+                    hm
+                },
             }),
             ..Default::default()
         };
@@ -425,7 +430,7 @@ mod test_user {
             serde_json::to_string(&event).unwrap(),
             "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"user\":\
              {\"id\":\"8fd5a33b-5b0e-45b2-aff2-9e4f067756ba\",\"email\":\"foo@example.invalid\",\
-             \"ip_address\":\"127.0.0.1\",\"username\":\"john-doe\"}}"
+             \"ip_address\":\"127.0.0.1\",\"username\":\"john-doe\",\"foo\":\"bar\"}}"
         );
     }
 


### PR DESCRIPTION
This brings back the `other` catch-all field for:

 - [x] `User`
 - [x] all `Context` types
 - [x] a `Context::Other` variant for arbitrary contexts

**NOTE**: The `Other` context is now discriminated by `"unknown"` as in marshal.
Like in the prior implementation, there is no supported way to override this
discriminator value at the current moment.

Fixes \#27