### PR TITLE
fix(v7): Correctly report client SDK packages

### DIFF
--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -1039,14 +1039,14 @@ pub struct ClientSdkInfo {
     pub integrations: Vec<String>,
     /// An optional list of packages that are installed in the SDK's environment.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub packages: Vec<ClientSdkPackageInfo>,
+    pub packages: Vec<ClientSdkPackage>,
 }
 
 /// Represents an installed package relevant to the SDK.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct ClientSdkPackageInfo {
+pub struct ClientSdkPackage {
     /// The name of the package installed.
-    pub package_name: String,
+    pub name: String,
     /// The version of the package.
     pub version: String,
 }

--- a/tests/test_protocol_v7.rs
+++ b/tests/test_protocol_v7.rs
@@ -1143,8 +1143,8 @@ fn test_sdk_info() {
             name: "sentry-rust".into(),
             version: "1.0".into(),
             integrations: vec!["rocket".into()],
-            packages: vec![v7::ClientSdkPackageInfo {
-                package_name: "crates:sentry".into(),
+            packages: vec![v7::ClientSdkPackage {
+                name: "cargo:sentry".into(),
                 version: "1.0".into(),
             }],
         })),
@@ -1156,7 +1156,7 @@ fn test_sdk_info() {
         serde_json::to_string(&event).unwrap(),
         "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"sdk\":\
          {\"name\":\"sentry-rust\",\"version\":\"1.0\",\"integrations\":[\"rocket\"],\"packages\":\
-         [{\"package_name\":\"crates:sentry\",\"version\":\"1.0\"}]}}"
+         [{\"name\":\"cargo:sentry\",\"version\":\"1.0\"}]}}"
     );
 }
 


### PR DESCRIPTION
When reviewing \#24, I did not realize that we actually require to send the
package name as `name` and not `package_name`. While at it, I also chose to
shorten the struct's name to `ClientSdkPackage` from `ClientSdkPackageInfo`,
as the suffix seemed a bit redundant.

**THIS IS A BREAKING CHANGE!**