### PR TITLE
ref: Discard invalid timestamps in Auth

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -19,9 +19,6 @@ pub enum AuthParseError {
     /// Raised if the auth header is not indicating sentry auth
     #[fail(display = "non sentry auth")]
     NonSentryAuth,
-    /// Raised if the timestamp value is invalid.
-    #[fail(display = "invalid value for timestamp")]
-    InvalidTimestamp,
     /// Raised if the version value is invalid
     #[fail(display = "invalid value for version")]
     InvalidVersion,
@@ -69,9 +66,9 @@ impl Auth {
                         .parse()
                         .ok()
                         .and_then(|ts| timestamp_to_datetime(ts).single())
-                        .or_else(|| value.parse().ok())
-                        .ok_or(AuthParseError::InvalidTimestamp)?;
-                    rv.timestamp = Some(timestamp);
+                        .or_else(|| value.parse().ok());
+
+                    rv.timestamp = timestamp;
                 }
                 "client" => {
                     rv.client = Some(value.into());

--- a/tests/test_auth.rs
+++ b/tests/test_auth.rs
@@ -133,3 +133,9 @@ fn test_auth_from_json() {
     assert_eq!(auth.public_key(), "4bb5d94de752a36b8b87851a3f82726a");
     assert_eq!(auth.secret_key(), None);
 }
+
+#[test]
+fn test_auth_string_timestamp() {
+    let auth = Auth::from_querystring(b"sentry_version=7&sentry_client=raven-clj&sentry_key=4bb5d94de752a36b8b87851a3f82726a&sentry_timestamp=2019-12-13 12:02:58.94").unwrap();
+    assert_eq!(auth.timestamp(), None);
+}


### PR DESCRIPTION
It seems that raven-clj, until recently, sent in an ISO-formatted timestamp: https://github.com/sethtrain/raven-clj/pull/28

It also seems the reason this ever worked in Sentry was because Sentry just discarded the value.