### PR TITLE
fix(auth): Only accept sentry_ prefixed auth keys

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -56,12 +56,8 @@ impl Auth {
         };
 
         for (key, value) in pairs {
-            let mut key = &key[..];
-            if key.starts_with("sentry_") {
-                key = &key[7..];
-            }
-            match key {
-                "timestamp" => {
+            match key.as_ref() {
+                "sentry_timestamp" => {
                     let timestamp = value
                         .parse()
                         .ok()
@@ -70,20 +66,20 @@ impl Auth {
 
                     rv.timestamp = timestamp;
                 }
-                "client" => {
+                "sentry_client" => {
                     rv.client = Some(value.into());
                 }
-                "version" => {
+                "sentry_version" => {
                     rv.version = value
                         .splitn(2, '.')
                         .next()
                         .and_then(|v| v.parse().ok())
                         .ok_or(AuthParseError::InvalidVersion)?;
                 }
-                "key" => {
+                "sentry_key" => {
                     rv.key = value.into();
                 }
-                "secret" => {
+                "sentry_secret" => {
                     rv.secret = Some(value.into());
                 }
                 _ => {}

--- a/tests/test_auth.rs
+++ b/tests/test_auth.rs
@@ -55,7 +55,7 @@ fn test_auth_from_iterator() {
     cont.insert("sentry_client", "raven-js/3.23.3");
     cont.insert("sentry_key", "4bb5d94de752a36b8b87851a3f82726a");
 
-    let auth = Auth::from_pairs(cont.into_iter().map(|(k, v)| (k.into(), v.into()))).unwrap();
+    let auth = Auth::from_pairs(cont.into_iter()).unwrap();
     assert_eq!(auth.timestamp(), None);
     assert_eq!(auth.client_agent(), Some("raven-js/3.23.3"));
     assert_eq!(auth.version(), 7);
@@ -67,7 +67,7 @@ fn test_auth_from_iterator() {
     cont.insert("client", "raven-js/3.23.3");
     cont.insert("key", "4bb5d94de752a36b8b87851a3f82726a");
 
-    let auth = Auth::from_pairs(cont.into_iter().map(|(k, v)| (k.into(), v.into()))).unwrap();
+    let auth = Auth::from_pairs(cont.into_iter()).unwrap();
     assert_eq!(auth.timestamp(), None);
     assert_eq!(auth.client_agent(), Some("raven-js/3.23.3"));
     assert_eq!(auth.version(), 7);
@@ -115,7 +115,7 @@ fn test_auth_to_json() {
     cont.insert("sentry_client", "raven-js/3.23.3");
     cont.insert("sentry_key", "4bb5d94de752a36b8b87851a3f82726a");
 
-    let auth = Auth::from_pairs(cont.into_iter().map(|(k, v)| (k.into(), v.into()))).unwrap();
+    let auth = Auth::from_pairs(cont.into_iter()).unwrap();
     assert_eq!(
         serde_json::to_string(&auth).expect("could not serialize").as_str(),
         "{\"sentry_client\":\"raven-js/3.23.3\",\"sentry_version\":7,\"sentry_key\":\"4bb5d94de752a36b8b87851a3f82726a\",\"sentry_secret\":null}"

--- a/tests/test_auth.rs
+++ b/tests/test_auth.rs
@@ -61,34 +61,11 @@ fn test_auth_from_iterator() {
     assert_eq!(auth.version(), 7);
     assert_eq!(auth.public_key(), "4bb5d94de752a36b8b87851a3f82726a");
     assert_eq!(auth.secret_key(), None);
-
-    let mut cont = HashMap::new();
-    cont.insert("version", "7");
-    cont.insert("client", "raven-js/3.23.3");
-    cont.insert("key", "4bb5d94de752a36b8b87851a3f82726a");
-
-    let auth = Auth::from_pairs(cont.into_iter()).unwrap();
-    assert_eq!(auth.timestamp(), None);
-    assert_eq!(auth.client_agent(), Some("raven-js/3.23.3"));
-    assert_eq!(auth.version(), 7);
-    assert_eq!(auth.public_key(), "4bb5d94de752a36b8b87851a3f82726a");
-    assert_eq!(auth.secret_key(), None);
 }
 
 #[test]
 fn test_auth_from_querystring() {
     let auth = Auth::from_querystring(b"sentry_version=7&sentry_client=raven-js/3.23.3&sentry_key=4bb5d94de752a36b8b87851a3f82726a").unwrap();
-
-    assert_eq!(auth.timestamp(), None);
-    assert_eq!(auth.client_agent(), Some("raven-js/3.23.3"));
-    assert_eq!(auth.version(), 7);
-    assert_eq!(auth.public_key(), "4bb5d94de752a36b8b87851a3f82726a");
-    assert_eq!(auth.secret_key(), None);
-
-    let auth = Auth::from_querystring(
-        b"version=7&client=raven-js/3.23.3&key=4bb5d94de752a36b8b87851a3f82726a",
-    )
-    .unwrap();
 
     assert_eq!(auth.timestamp(), None);
     assert_eq!(auth.client_agent(), Some("raven-js/3.23.3"));


### PR DESCRIPTION
Aligns auth parsing closer with Sentry:
https://github.com/getsentry/sentry/blob/a57b833d9167d5ea1938d4e55778209f9b2cd4ce/src/sentry/coreapi.py#L180-L181