### PR TITLE
feat(project_id): Expose the numeric value of ProjectId

### DIFF
--- a/src/dsn.rs
+++ b/src/dsn.rs
@@ -223,7 +223,7 @@ mod test {
         assert_eq!(dsn.host(), "domain");
         assert_eq!(dsn.port(), 8888);
         assert_eq!(dsn.path(), "/");
-        assert_eq!(dsn.project_id(), ProjectId::from(23));
+        assert_eq!(dsn.project_id(), ProjectId::new(23));
         assert_eq!(url, dsn.to_string());
     }
 

--- a/src/project_id.rs
+++ b/src/project_id.rs
@@ -1,23 +1,8 @@
+use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
 
 use failure::Fail;
-
-/// Represents a project ID.
-///
-/// This is a thin wrapper around IDs supported by the Sentry
-/// server.  The idea is that the sentry server generally can
-/// switch the ID format in the future (eg: we implement the IDs
-/// as strings and not as integers) but the actual ID format that
-/// is encountered are currently indeed integers.
-///
-/// To be future proof we support either integers or "short"
-/// strings.
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub struct ProjectId {
-    // for now the only supported format is indeed an u64
-    val: u64,
-}
 
 /// Raised if a project ID cannot be parsed from a string.
 #[derive(Debug, Fail, PartialEq, Eq, PartialOrd, Ord)]
@@ -30,37 +15,73 @@ pub enum ProjectIdParseError {
     EmptyValue,
 }
 
+/// Represents a project ID.
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub struct ProjectId(u64);
+
+impl ProjectId {
+    /// Creates a new project ID from its numeric value.
+    #[inline]
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Returns the numeric value of this project id.
+    #[inline]
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
 impl fmt::Display for ProjectId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.val)
+        write!(f, "{}", self.value())
     }
 }
 
 impl fmt::Debug for ProjectId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{}", self.value())
     }
 }
 
 macro_rules! impl_from {
     ($ty:ty) => {
         impl From<$ty> for ProjectId {
-            fn from(val: $ty) -> ProjectId {
-                ProjectId { val: val as u64 }
+            #[inline]
+            fn from(val: $ty) -> Self {
+                Self::new(val as u64)
             }
         }
     };
 }
 
-impl_from!(usize);
 impl_from!(u8);
 impl_from!(u16);
 impl_from!(u32);
 impl_from!(u64);
-impl_from!(i8);
-impl_from!(i16);
-impl_from!(i32);
-impl_from!(i64);
+
+macro_rules! impl_try_from {
+    ($ty:ty) => {
+        impl TryFrom<$ty> for ProjectId {
+            type Error = ProjectIdParseError;
+
+            #[inline]
+            fn try_from(val: $ty) -> Result<Self, Self::Error> {
+                match u64::try_from(val) {
+                    Ok(id) => Ok(Self::new(id)),
+                    Err(_) => Err(ProjectIdParseError::InvalidValue),
+                }
+            }
+        }
+    };
+}
+
+impl_try_from!(usize);
+impl_try_from!(i8);
+impl_try_from!(i16);
+impl_try_from!(i32);
+impl_try_from!(i64);
 
 impl FromStr for ProjectId {
     type Err = ProjectIdParseError;
@@ -69,8 +90,9 @@ impl FromStr for ProjectId {
         if s.is_empty() {
             return Err(ProjectIdParseError::EmptyValue);
         }
+
         match s.parse::<u64>() {
-            Ok(val) => Ok(ProjectId { val }),
+            Ok(val) => Ok(ProjectId::new(val)),
             Err(_) => Err(ProjectIdParseError::InvalidValue),
         }
     }
@@ -86,7 +108,7 @@ mod test {
     #[test]
     fn test_basic_api() {
         let id: ProjectId = "42".parse().unwrap();
-        assert_eq!(id, ProjectId::from(42));
+        assert_eq!(id, ProjectId::new(42));
         assert_eq!(
             "42xxx".parse::<ProjectId>(),
             Err(ProjectIdParseError::InvalidValue)
@@ -95,15 +117,15 @@ mod test {
             "".parse::<ProjectId>(),
             Err(ProjectIdParseError::EmptyValue)
         );
-        assert_eq!(ProjectId::from(42).to_string(), "42");
+        assert_eq!(ProjectId::new(42).to_string(), "42");
 
         assert_eq!(
-            serde_json::to_string(&ProjectId::from(42)).unwrap(),
+            serde_json::to_string(&ProjectId::new(42)).unwrap(),
             "\"42\""
         );
         assert_eq!(
             serde_json::from_str::<ProjectId>("\"42\"").unwrap(),
-            ProjectId::from(42)
+            ProjectId::new(42)
         );
     }
 }


### PR DESCRIPTION
We've committed to keeping project IDs numeric, so we can expose its value now.