### PR TITLE
ref: Replace failure with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ with_serde = []
 travis-ci = { repository = "getsentry/rust-sentry-types" }
 
 [dependencies]
-failure = "0.1.6"
-url = { version = "2.1.1", features = ["serde"] }
+thiserror = "1.0.15"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.46"
+url = { version = "2.1.1", features = ["serde"] }
 chrono = { version = "0.4.10", features = ["serde"] }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 debugid = { version = "0.7.0", features = ["serde"] }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -119,7 +119,7 @@ impl Auth {
 
     /// Returns the client's secret if it authenticated with a secret.
     pub fn secret_key(&self) -> Option<&str> {
-        self.secret.as_ref().map(|x| x.as_str())
+        self.secret.as_deref()
     }
 
     /// Returns true if the authentication implies public auth (no secret)
@@ -129,7 +129,7 @@ impl Auth {
 
     /// Returns the client's agent
     pub fn client_agent(&self) -> Option<&str> {
-        self.client.as_ref().map(|x| x.as_str())
+        self.client.as_deref()
     }
 }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
-use failure::Fail;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use url::form_urlencoded;
 
 use crate::dsn::Dsn;
@@ -14,16 +14,16 @@ use crate::protocol;
 use crate::utils::{datetime_to_timestamp, timestamp_to_datetime};
 
 /// Represents an auth header parsing error.
-#[derive(Debug, Fail, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Error, Copy, Clone, Eq, PartialEq)]
 pub enum ParseAuthError {
     /// Raised if the auth header is not indicating sentry auth
-    #[fail(display = "non sentry auth")]
+    #[error("non sentry auth")]
     NonSentryAuth,
     /// Raised if the version value is invalid
-    #[fail(display = "invalid value for version")]
+    #[error("invalid value for version")]
     InvalidVersion,
     /// Raised if the public key is missing entirely
-    #[fail(display = "missing public key in auth header")]
+    #[error("missing public key in auth header")]
     MissingPublicKey,
 }
 

--- a/src/dsn.rs
+++ b/src/dsn.rs
@@ -105,7 +105,7 @@ impl Dsn {
 
     /// Returns secret_key
     pub fn secret_key(&self) -> Option<&str> {
-        self.secret_key.as_ref().map(|x| x.as_str())
+        self.secret_key.as_deref()
     }
 
     /// Returns the host

--- a/src/dsn.rs
+++ b/src/dsn.rs
@@ -1,30 +1,30 @@
 use std::fmt;
 use std::str::FromStr;
 
-use failure::Fail;
+use thiserror::Error;
 use url::Url;
 
 use crate::auth::{auth_from_dsn_and_client, Auth};
 use crate::project_id::{ParseProjectIdError, ProjectId};
 
 /// Represents a dsn url parsing error.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum ParseDsnError {
     /// raised on completely invalid urls
-    #[fail(display = "no valid url provided")]
+    #[error("no valid url provided")]
     InvalidUrl,
     /// raised the scheme is invalid / unsupported.
-    #[fail(display = "no valid scheme")]
+    #[error("no valid scheme")]
     InvalidScheme,
     /// raised if the username (public key) portion is missing.
-    #[fail(display = "username is empty")]
+    #[error("username is empty")]
     NoUsername,
     /// raised the project is is missing (first path component)
-    #[fail(display = "empty path")]
+    #[error("empty path")]
     NoProjectId,
     /// raised the project id is invalid.
-    #[fail(display = "invalid project id")]
-    InvalidProjectId(#[cause] ParseProjectIdError),
+    #[error("invalid project id")]
+    InvalidProjectId(#[from] ParseProjectIdError),
 }
 
 /// Represents the scheme of an url http/https.

--- a/src/project_id.rs
+++ b/src/project_id.rs
@@ -2,17 +2,17 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
 
-use failure::Fail;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// Raised if a project ID cannot be parsed from a string.
-#[derive(Debug, Fail, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Error, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ParseProjectIdError {
     /// Raised if the value is not an integer in the supported range.
-    #[fail(display = "invalid value for project id")]
+    #[error("invalid value for project id")]
     InvalidValue,
     /// Raised if an empty value is parsed.
-    #[fail(display = "empty or missing project id")]
+    #[error("empty or missing project id")]
     EmptyValue,
 }
 

--- a/src/protocol/v7.rs
+++ b/src/protocol/v7.rs
@@ -16,9 +16,9 @@ use std::str;
 
 use ::debugid::DebugId;
 use chrono::{DateTime, Utc};
-use failure::Fail;
 use serde::Serializer;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use url::Url;
 use uuid::Uuid;
 
@@ -634,8 +634,8 @@ pub struct Exception {
 }
 
 /// An error used when parsing `Level`.
-#[derive(Debug, Fail)]
-#[fail(display = "invalid level")]
+#[derive(Debug, Error)]
+#[error("invalid level")]
 pub struct ParseLevelError;
 
 /// Represents the level of severity of an event or breadcrumb.


### PR DESCRIPTION
This is a *breaking change*, as `Fail` types had public API.

Total number of comiled crates goes from 69->60, although the compile
time wins are not that large (<10%) on my 8C/16T Windows.